### PR TITLE
SPT-1409: Changed TXMA timestamp field to number

### DIFF
--- a/src/message-processor/message-processor.test.ts
+++ b/src/message-processor/message-processor.test.ts
@@ -26,7 +26,7 @@ const DEFAULT_CONFIGURATION: Configuration = Object.freeze({
 
 const VALID_TXMA_MESSAGE: TxmaMessage = Object.freeze({
   user_id: "test-user-id",
-  timestamp: String(Date.now()),
+  timestamp: Math.floor(Date.now() / 1000),
   intervention_code: "12",
 });
 
@@ -112,22 +112,22 @@ describe("message-processor", () => {
     const sqsEvent = createTestSQSEvent<TxmaMessage>(
       {
         user_id: "bob.smith-12345",
-        timestamp: "1752755394232",
+        timestamp: 1752755394,
         intervention_code: "01",
       },
       {
         user_id: "jane.smith-12345",
-        timestamp: "1752755454558",
+        timestamp: 1752755454,
         intervention_code: "12",
       },
       {
         user_id: "cyril.jones-12345",
-        timestamp: "1752755496130",
+        timestamp: 1752755496,
         intervention_code: "23",
       },
       {
         user_id: "helen.jones-12345",
-        timestamp: "1752755496130",
+        timestamp: 1752755496,
         intervention_code: "34",
       }
     );
@@ -193,7 +193,7 @@ describe("message-processor", () => {
 
     const sqsEvent = createTestSQSEvent<TxmaMessage>({
       user_id: "jane.smith-12345",
-      timestamp: "1752755454558",
+      timestamp: 1752755454,
       intervention_code: "12",
     });
 
@@ -244,7 +244,7 @@ describe("message-processor", () => {
 
     const sqsEvent = createTestSQSEvent<TxmaMessage>({
       user_id: "jane.smith-12345",
-      timestamp: "1752755454558",
+      timestamp: 1752755454,
       intervention_code: "12",
     });
 

--- a/src/types/txmaMessage.ts
+++ b/src/types/txmaMessage.ts
@@ -10,7 +10,7 @@ export type TxmaMessage = {
   /**
    * Records the time and date of when the event occurred.
    */
-  timestamp: string;
+  timestamp: number;
   /**
    * The code of the type of intervention that was applied to the account
    */
@@ -30,8 +30,8 @@ const isStringWithLength = (value: unknown): value is string => typeof value ===
  * @param request - The TXMA message
  * @returns true if this is a TXMA message and casts it to a TxmaMessage object
  */
-export const isTxmaMessage = (request: Record<string, string>): request is TxmaMessage =>
+export const isTxmaMessage = (request: Record<string, string | number>): request is TxmaMessage =>
   request &&
   isStringWithLength(request.user_id) &&
-  isStringWithLength(request.timestamp) &&
+  typeof request.timestamp === "number" &&
   isStringWithLength(request.intervention_code);


### PR DESCRIPTION
## Proposed changes

### What changed

* Changed TXMA timestamp field to `number`.
* Updated `message-processor.test.ts` to use seconds rather than milliseconds for the Epoch as this is expected by TXMA.

### Why did it change

The TXMA service uses `numbers` instead of `strings`.

### Issue tracking

- SPT-1409

## Testing

Updated unit tests and also tested manually by injecting messages into SQS.

### Manual Steps to Test

#### Tested using timestamp as a `string` - Result PASSED

**Input:**
```json
{
  "intervention_code":"01",
  "timestamp":"1753186155",
   "user_id":"urn:fdc:gov.uk:2022:abcd"
}
```

**Expected outcome**
The `timestamp` field should be a `number` and not a `string` as previously thought. The message should be rejected and returned to the dead letter queue.

**Actual outcome**
The message was rejected, SQS tried to redrive the message a number of times before rejecting the message.

| Event Time | Message |
| --- | --- |
| 2025-07-23T07:59:08.303Z | START RequestId: a556a0c5-988c-5b15-82cb-c03f00f624e7 Version: $LATEST |
| 2025-07-23T07:59:08.304Z | 2025-07-23T07:59:08.304Z a556a0c5-988c-5b15-82cb-c03f00f624e7 ERROR Invoke Error  {"errorType":"Error","errorMessage":"SQS record 0 does not have required fields","stack":["Error: SQS record 0 does not have required fields","    at <anonymous> (/private/var/folders/r5/4dd92cln4vl4k2gjs4w8v69m0000gp/T/tmps4aflzg2/src/message-processor/message-processor.ts:107:11)","    at Array.map (<anonymous>)","    at records (/private/var/folders/r5/4dd92cln4vl4k2gjs4w8v69m0000gp/T/tmps4aflzg2/src/message-processor/message-processor.ts:97:11)","    at Runtime.Iue (/private/var/folders/r5/4dd92cln4vl4k2gjs4w8v69m0000gp/T/tmps4aflzg2/src/message-processor/message-processor.ts:20:19)","    at Runtime.handleOnceNonStreaming (file:///var/runtime/index.mjs:1205:29)"]} |
| 2025-07-23T07:59:08.305Z | END RequestId: a556a0c5-988c-5b15-82cb-c03f00f624e7 |
| 2025-07-23T07:59:08.305Z | REPORT RequestId: a556a0c5-988c-5b15-82cb-c03f00f624e7 Duration: 2.59 ms Billed Duration: 3 ms Memory Size: 1024 MB Max Memory Used: 131 MB  XRAY TraceId: 1-6880964c-3050ee9a10f6b37d85bffd59 SegmentId: 4a42684270cdc608 Sampled: true |

#### Tested using timestamp as a `number` - Result PASSED

**Input:**
```json
{
  "intervention_code":"01",
  "timestamp":1753186155,
  "user_id":"urn:fdc:gov.uk:2022:abcd"
}
```

**Expected outcome**
The message should not be rejected by the service.

**Actual outcome**
The message was successfully processed.

---
| Event Time | Message |
| --- | --- |
| 2025-07-23T08:03:46.889Z | START RequestId: f2267d08-67c6-5b53-8eae-1df2fe498ad9 Version: $LATEST |
| 2025-07-23T08:03:47.085Z | {"_aws":{"Timestamp":1753257827085,"CloudWatchMetrics":[{"Namespace":"dev-chrisp-TXMAMessageProcessor","Dimensions":[["service"]],"Metrics":[{"Name":"MessagesReceived","Unit":"Count"}]}]},"service":"MessagesReceived","MessagesReceived":1} |
| 2025-07-23T08:03:47.086Z | END RequestId: f2267d08-67c6-5b53-8eae-1df2fe498ad9 |
| 2025-07-23T08:03:47.086Z | REPORT RequestId: f2267d08-67c6-5b53-8eae-1df2fe498ad9 Duration: 196.92 ms Billed Duration: 197 ms Memory Size: 1024 MB Max Memory Used: 131 MB  XRAY TraceId: 1-68809762-6c33aeaff8a9324b5a669397 SegmentId: 20a4c17156fbc9ec Sampled: true |
---

#### Tested including all fields - Result PASSED

**Input:**
```json
{
  "event_id": "E2C303C1-C35F-4216-BB7B-7B973010A9CE",
  "intervention_code": "01",
  "timestamp": 1753186155,
  "user_id": "urn:fdc:gov.uk:2022:abcd",
  "txma": { "configVersion": "1.0.2" }
}
```

**Expected outcome**
The message should not be rejected by the service.

**Actual outcome**
The message was successfully processed.

---
| Event Time | Message |
| --- | --- |
| 2025-07-23T08:07:00.086Z | START RequestId: 35df9279-d6d7-5e40-812a-f2834c8fa752 Version: $LATEST |
| 2025-07-23T08:07:00.268Z | {"_aws":{"Timestamp":1753258020268,"CloudWatchMetrics":[{"Namespace":"dev-chrisp-TXMAMessageProcessor","Dimensions":[["service"]],"Metrics":[{"Name":"MessagesReceived","Unit":"Count"}]}]},"service":"MessagesReceived","MessagesReceived":1} |
| 2025-07-23T08:07:00.269Z | END RequestId: 35df9279-d6d7-5e40-812a-f2834c8fa752 |
| 2025-07-23T08:07:00.269Z | REPORT RequestId: 35df9279-d6d7-5e40-812a-f2834c8fa752 Duration: 183.43 ms Billed Duration: 184 ms Memory Size: 1024 MB Max Memory Used: 131 MB  XRAY TraceId: 1-68809824-5bef14954d23899b4e55626c SegmentId: 3d27ceb52db25fd9 Sampled: true |
---

## Checklists

### Checklist for developers

- [x]  The PR description is filled out and the PR title includes the story reference
- [ ]  If there will be further PRs related to the story, this is highlighted in the PR description what is to come
- [ ]  There are no merge, WIP or reversion commits included in the PR (reversion commits allowed if reverting previously merged code)
- [x]  All commits include story reference, a distinct title and a body listing changes
- [x]  All commits are signed
- [x]  All commits contain a `Co-authored-by` line where pairing has taken place
- [x]  All changes in this PR are related to the story
- [x]  The changes have been fully tested in the dev environment
- [x]  There are unit and/or integration tests matching story acceptance criteria (where applicable)
- [ ]  Any feature flags are correctly set for each target environment
- [ ]  Any related configuration changes have been merged and have landed in the target environment(s)
- [ ]  Any related platform changes have been merged and have been applied in the target environment(s)
- [ ]  This change will deploy with zero downtime (consider the blue/green nature of our deployments)
- [ ]  Any Sonarcloud issues are addressed or dismissed with a valid reason
- [ ]  Any exceptions to any of the above statements are documented in the description and agreed with the reviewer

### Checklist for reviewers

- [ ]  The above statements are all true
- [ ]  The change meets the acceptance criteria set out in the story
- [ ]  There are no missing test scenarios
- [ ]  The code is readable and understandable
- [ ]  The code is maintainable and does not present any notable technical debt
- [ ]  There are no outstanding Sonarcloud issues, and you agree with any dismissal reasons
