### PR TITLE
SPT-1574: Use the new ARN for CSLS filters

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -356,7 +356,7 @@ Resources:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDev
     Properties:
-      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
+      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython-2"
       FilterPattern: "{$._aws.CloudWatchMetrics NOT EXISTS}"
       LogGroupName: !Ref MessageProcessorLambdaLogGroup
 


### PR DESCRIPTION
## Proposed changes

### What changed

Use `prodpython-2` variant of the CSLS filter, this is the correct version for newer accounts to use. 

### Why did it change

We are getting deployment errors with the original one.

## Checklists

### Checklist for developers

- [ ]  The PR description is filled out and the PR title includes the story reference
- [ ]  If there will be further PRs related to the story, this is highlighted in the PR description what is to come
- [ ]  There are no merge, WIP or reversion commits included in the PR (reversion commits allowed if reverting previously merged code)
- [ ]  All commits include story reference, a distinct title and a body listing changes
- [ ]  All commits are signed
- [ ]  All commits contain a `Co-authored-by` line where pairing has taken place
- [ ]  All changes in this PR are related to the story
- [ ]  The changes have been fully tested in the dev environment
- [ ]  There are unit and/or integration tests matching story acceptance criteria (where applicable)
- [ ]  Any feature flags are correctly set for each target environment
- [ ]  Any related configuration changes have been merged and have landed in the target environment(s)
- [ ]  Any related platform changes have been merged and have been applied in the target environment(s)
- [ ]  This change will deploy with zero downtime (consider the blue/green nature of our deployments)
- [ ]  Any Sonarcloud issues are addressed or dismissed with a valid reason
- [ ]  Any exceptions to any of the above statements are documented in the description and agreed with the reviewer

### Checklist for reviewers

- [ ]  The above statements are all true
- [ ]  The change meets the acceptance criteria set out in the story
- [ ]  There are no missing test scenarios
- [ ]  The code is readable and understandable
- [ ]  The code is maintainable and does not present any notable technical debt
- [ ]  There are no outstanding Sonarcloud issues, and you agree with any dismissal reasons
