### PR TITLE
SPT-1511: Remove path filter in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,7 +46,6 @@ jobs:
         uses: actions/download-artifact@v5
         with:
           name: ${{ inputs.artifact-name }}
-          path: .aws-sam/build
 
       - name: Assume AWS role
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1


### PR DESCRIPTION
## Proposed changes

### What changed

- Remove the path filter from the `download-artifact` action in the publish workflow .

### Why did it change

We are getting deployment failures while trying to publish the artefact to CodePipeline.

## Checklists

### Checklist for developers

- [ ]  The PR description is filled out and the PR title includes the story reference
- [ ]  If there will be further PRs related to the story, this is highlighted in the PR description what is to come
- [ ]  There are no merge, WIP or reversion commits included in the PR (reversion commits allowed if reverting previously merged code)
- [ ]  All commits include story reference, a distinct title and a body listing changes
- [ ]  All commits are signed
- [ ]  All commits contain a `Co-authored-by` line where pairing has taken place
- [ ]  All changes in this PR are related to the story
- [ ]  The changes have been fully tested in the dev environment
- [ ]  There are unit and/or integration tests matching story acceptance criteria (where applicable)
- [ ]  Any feature flags are correctly set for each target environment
- [ ]  Any related configuration changes have been merged and have landed in the target environment(s)
- [ ]  Any related platform changes have been merged and have been applied in the target environment(s)
- [ ]  This change will deploy with zero downtime (consider the blue/green nature of our deployments)
- [ ]  Any Sonarcloud issues are addressed or dismissed with a valid reason
- [ ]  Any exceptions to any of the above statements are documented in the description and agreed with the reviewer

### Checklist for reviewers

- [ ]  The above statements are all true
- [ ]  The change meets the acceptance criteria set out in the story
- [ ]  There are no missing test scenarios
- [ ]  The code is readable and understandable
- [ ]  The code is maintainable and does not present any notable technical debt
- [ ]  There are no outstanding Sonarcloud issues, and you agree with any dismissal reasons
