### PR TITLE
SPT-1621: Reinstate acceptance tests post-merge

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -65,25 +65,22 @@ jobs:
       aws-role-arn: ${{ secrets.GHA_AWS_ROLE_ARN }}
       aws-s3-bucket: ${{ secrets.GHA_SAM_DEPLOYMENT_BUCKET }}
 
-  # TODO: Disabled at the moment due to WAF rules needing to be added for mock.credential-store.dev.account.gov.uk
-  #
-  # acceptance-test:
-  #   uses: ./.github/workflows/acceptance-tests.yml
-  #   needs:
-  #     - preview-main
-  #   permissions:
-  #     id-token: write
-  #     contents: read
-  #   with:
-  #     stack-name: ${{ needs.preview-main.outputs.stack-name }}
-  #   secrets:
-  #     aws-role-arn: ${{ secrets.GHA_AWS_ROLE_ARN }}
+  acceptance-test:
+   uses: ./.github/workflows/acceptance-tests.yml
+   needs:
+     - preview-main
+   permissions:
+     id-token: write
+     contents: read
+   with:
+     stack-name: ${{ needs.preview-main.outputs.stack-name }}
+   secrets:
+     aws-role-arn: ${{ secrets.GHA_AWS_ROLE_ARN }}
 
   publish-test-image:
     uses: ./.github/workflows/publish-test-image.yml
     needs:
-      # - acceptance-test
-      - preview-main
+      - acceptance-test
       - detect-changes
     if: needs.detect-changes.outputs.acceptance-tests-changed == 'true'
     permissions:
@@ -100,12 +97,11 @@ jobs:
     uses: ./.github/workflows/publish.yml
     needs:
       - publish-test-image
-      # - acceptance-test
-      - preview-main
+      - acceptance-test
     if: |
       always() &&
       (needs.publish-test-image.result == 'success' || needs.publish-test-image.result == 'skipped') &&
-      (needs.preview-main.result == 'success')
+      (needs.acceptance-test.result == 'success')
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Proposed changes

### What changed

- Uncomment the acceptance tests from the post-merge action.
- Reconfigure the `needs` of the subsequent jobs to wait for the acceptance tests to pass.

### Why did it change

The tests are now working, these should be run post-merge before pushing to the pipelines for delivery.

## Testing

See this [job](https://github.com/govuk-one-login/ipv-identity-reuse-service/actions/runs/18014623577) run to show the post merge action running against a branch with the acceptance tests in place.

## Checklists

### Checklist for developers

- [x]  The PR description is filled out and the PR title includes the story reference
- [ ]  If there will be further PRs related to the story, this is highlighted in the PR description what is to come
- [x]  There are no merge, WIP or reversion commits included in the PR (reversion commits allowed if reverting previously merged code)
- [x]  All commits include story reference, a distinct title and a body listing changes
- [x]  All commits are signed
- [ ]  All commits contain a `Co-authored-by` line where pairing has taken place
- [x]  All changes in this PR are related to the story
- [x]  The changes have been fully tested in the dev environment
- [ ]  There are unit and/or integration tests matching story acceptance criteria (where applicable)
- [ ]  Any feature flags are correctly set for each target environment
- [ ]  Any related configuration changes have been merged and have landed in the target environment(s)
- [ ]  Any related platform changes have been merged and have been applied in the target environment(s)
- [ ]  This change will deploy with zero downtime (consider the blue/green nature of our deployments)
- [ ]  Any Sonarcloud issues are addressed or dismissed with a valid reason
- [ ]  Any exceptions to any of the above statements are documented in the description and agreed with the reviewer

### Checklist for reviewers

- [ ]  The above statements are all true
- [ ]  The change meets the acceptance criteria set out in the story
- [ ]  There are no missing test scenarios
- [ ]  The code is readable and understandable
- [ ]  The code is maintainable and does not present any notable technical debt
- [ ]  There are no outstanding Sonarcloud issues, and you agree with any dismissal reasons
