### PR TITLE
SPT-1621: Add verbosity to test image & ensure working directory

### DIFF
--- a/tests/acceptance/run-tests.sh
+++ b/tests/acceptance/run-tests.sh
@@ -2,12 +2,17 @@
 TEST_REPORT_ABSOLUTE_DIR="${TEST_REPORT_ABSOLUTE_DIR:-/app/reports}"
 
 if [ ! -d "${TEST_REPORT_ABSOLUTE_DIR}" ]; then
+  echo "Creating directory ${TEST_REPORT_ABSOLUTE_DIR}"
   mkdir "${TEST_REPORT_ABSOLUTE_DIR}"
 fi
 
+echo "Test reports will be written to ${TEST_REPORT_ABSOLUTE_DIR}"
+
+cd /app
 echo Running acceptance tests...
 ./node_modules/.bin/cucumber-js \
   --require './dist/tests/acceptance/steps/*.js' \
   --format "json:${TEST_REPORT_ABSOLUTE_DIR}/cucumber.json" \
+  --format pretty \
   --tags 'not @ignore' \
   ./features


### PR DESCRIPTION
## Proposed changes

### What changed

- Add some `echo` statement to show progress of `run-tests.sh`
- Add parameter to ensure Cucumber echos test progress
- Add `cd /app` prior to running the tests to ensure tests are run from the correct location (`WORKDIR` may get ignored in the when running in the pipeline).

### Why did it change

The first run of the test image in the pipeline failed, with no useful feedback, lets add some verbosity and also ensure correct working directory.

## Checklists

### Checklist for developers

- [ ]  The PR description is filled out and the PR title includes the story reference
- [ ]  If there will be further PRs related to the story, this is highlighted in the PR description what is to come
- [ ]  There are no merge, WIP or reversion commits included in the PR (reversion commits allowed if reverting previously merged code)
- [ ]  All commits include story reference, a distinct title and a body listing changes
- [ ]  All commits are signed
- [ ]  All commits contain a `Co-authored-by` line where pairing has taken place
- [ ]  All changes in this PR are related to the story
- [ ]  The changes have been fully tested in the dev environment
- [ ]  There are unit and/or integration tests matching story acceptance criteria (where applicable)
- [ ]  Any feature flags are correctly set for each target environment
- [ ]  Any related configuration changes have been merged and have landed in the target environment(s)
- [ ]  Any related platform changes have been merged and have been applied in the target environment(s)
- [ ]  This change will deploy with zero downtime (consider the blue/green nature of our deployments)
- [ ]  Any Sonarcloud issues are addressed or dismissed with a valid reason
- [ ]  Any exceptions to any of the above statements are documented in the description and agreed with the reviewer

### Checklist for reviewers

- [ ]  The above statements are all true
- [ ]  The change meets the acceptance criteria set out in the story
- [ ]  There are no missing test scenarios
- [ ]  The code is readable and understandable
- [ ]  The code is maintainable and does not present any notable technical debt
- [ ]  There are no outstanding Sonarcloud issues, and you agree with any dismissal reasons
