### PR TITLE
SPT-1621: Ensure overrides when deploying to dev preview-main

### DIFF
--- a/.github/workflows/deploy-to-aws.yml
+++ b/.github/workflows/deploy-to-aws.yml
@@ -129,7 +129,7 @@ jobs:
             --no-fail-on-empty-changeset \
             --capabilities CAPABILITY_NAMED_IAM \
             --tags DeploymentSource="GitHub Actions" StackType=Preview \
-            --parameter-overrides Environment="dev"
+            --parameter-overrides Environment="dev" VpcStackName=vpc
 
       - name: Report deployment
         run: echo "Deployed stack \`$STACK_NAME\`" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Proposed changes

### What changed

- Set the override of the `VpcStackName` when deploying to dev from GHA

### Why did it change

`preview-main` it is currently set to the original default of `none` but now we've changed the default we need to override to have it update.

## Checklists

### Checklist for developers

- [ ]  The PR description is filled out and the PR title includes the story reference
- [ ]  If there will be further PRs related to the story, this is highlighted in the PR description what is to come
- [ ]  There are no merge, WIP or reversion commits included in the PR (reversion commits allowed if reverting previously merged code)
- [ ]  All commits include story reference, a distinct title and a body listing changes
- [ ]  All commits are signed
- [ ]  All commits contain a `Co-authored-by` line where pairing has taken place
- [ ]  All changes in this PR are related to the story
- [ ]  The changes have been fully tested in the dev environment
- [ ]  There are unit and/or integration tests matching story acceptance criteria (where applicable)
- [ ]  Any feature flags are correctly set for each target environment
- [ ]  Any related configuration changes have been merged and have landed in the target environment(s)
- [ ]  Any related platform changes have been merged and have been applied in the target environment(s)
- [ ]  This change will deploy with zero downtime (consider the blue/green nature of our deployments)
- [ ]  Any Sonarcloud issues are addressed or dismissed with a valid reason
- [ ]  Any exceptions to any of the above statements are documented in the description and agreed with the reviewer

### Checklist for reviewers

- [ ]  The above statements are all true
- [ ]  The change meets the acceptance criteria set out in the story
- [ ]  There are no missing test scenarios
- [ ]  The code is readable and understandable
- [ ]  The code is maintainable and does not present any notable technical debt
- [ ]  There are no outstanding Sonarcloud issues, and you agree with any dismissal reasons
