### PR TITLE
SPT-1621: Use SSM instead of ListExports for Secret ARN

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
       "devDependencies": {
         "@aws-sdk/client-cloudformation": "3.883.0",
         "@aws-sdk/client-lambda": "3.883.0",
+        "@aws-sdk/client-ssm": "3.883.0",
         "@cucumber/cucumber": "12.2.0",
         "@cucumber/pretty-formatter": "2.1.0",
         "@eslint/eslintrc": "3.3.1",
@@ -589,6 +590,81 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm": {
+      "version": "3.883.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.883.0.tgz",
+      "integrity": "sha512-iqTo0elstBR9jgFlvNRVqb+DjR0j0R5cm9Fwm63RsMAcLJYXrSzMA2c6XZZEhbLzHt8ZkIot+yn4DnO5mIHriQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.883.0",
+        "@aws-sdk/credential-provider-node": "3.883.0",
+        "@aws-sdk/middleware-host-header": "3.873.0",
+        "@aws-sdk/middleware-logger": "3.876.0",
+        "@aws-sdk/middleware-recursion-detection": "3.873.0",
+        "@aws-sdk/middleware-user-agent": "3.883.0",
+        "@aws-sdk/region-config-resolver": "3.873.0",
+        "@aws-sdk/types": "3.862.0",
+        "@aws-sdk/util-endpoints": "3.879.0",
+        "@aws-sdk/util-user-agent-browser": "3.873.0",
+        "@aws-sdk/util-user-agent-node": "3.883.0",
+        "@smithy/config-resolver": "^4.1.5",
+        "@smithy/core": "^3.9.2",
+        "@smithy/fetch-http-handler": "^5.1.1",
+        "@smithy/hash-node": "^4.0.5",
+        "@smithy/invalid-dependency": "^4.0.5",
+        "@smithy/middleware-content-length": "^4.0.5",
+        "@smithy/middleware-endpoint": "^4.1.21",
+        "@smithy/middleware-retry": "^4.1.22",
+        "@smithy/middleware-serde": "^4.0.9",
+        "@smithy/middleware-stack": "^4.0.5",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/node-http-handler": "^4.1.1",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/smithy-client": "^4.5.2",
+        "@smithy/types": "^4.3.2",
+        "@smithy/url-parser": "^4.0.5",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.29",
+        "@smithy/util-defaults-mode-node": "^4.0.29",
+        "@smithy/util-endpoints": "^3.0.7",
+        "@smithy/util-middleware": "^4.0.5",
+        "@smithy/util-retry": "^4.0.7",
+        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/util-waiter": "^4.0.7",
+        "@types/uuid": "^9.0.1",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "devOptional": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@aws-sdk/client-sso": {
@@ -4115,7 +4191,7 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.0.7.tgz",
       "integrity": "sha512-mYqtQXPmrwvUljaHyGxYUIIRI3qjBTEb/f5QFi3A6VlxhpmZd5mWXn9W+qUkf2pVE1Hv3SqxefiZOPGdxmO64A==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/abort-controller": "^4.0.5",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@aws-sdk/client-cloudformation": "3.883.0",
     "@aws-sdk/client-lambda": "3.883.0",
+    "@aws-sdk/client-ssm": "3.883.0",
     "@cucumber/cucumber": "12.2.0",
     "@cucumber/pretty-formatter": "2.1.0",
     "@eslint/eslintrc": "3.3.1",

--- a/run-acceptance-tests.sh
+++ b/run-acceptance-tests.sh
@@ -11,12 +11,13 @@ Usage:
     -a      --aws-account       The AWS account to deploy to. (optional)
     -s      --stack-name        The name of your stack.
     -d      --docker            Run the tests using Docker and the acceptance testing image
+    -c      --shared-stack      The name of the shared configuration stack to use (defaults to reuse-identity-shared)
     -h      --help              Prints this help message and exits
 EOF
 }
 
 RUN_WITH_DOCKER=false
-
+SHARED_STACK_NAME=reuse-identity-shared
 while [ "$1" != "" ]; do
   case $1 in
   -a | --aws-account)
@@ -29,6 +30,10 @@ while [ "$1" != "" ]; do
     ;;
   -d | --docker)
     RUN_WITH_DOCKER=true
+    ;;
+  -c | --shared-stack)
+    shift
+    SHARED_STACK_NAME=$1
     ;;
   -h | --help)
     usage
@@ -59,6 +64,7 @@ if [ -z "$SAM_STACK_NAME" ]; then
 fi
 
 export TEST_ENVIRONMENT="dev"
+export SHARED_STACK_NAME
 export SAM_STACK_NAME
 if $RUN_WITH_DOCKER; then
   docker build \
@@ -74,6 +80,7 @@ if $RUN_WITH_DOCKER; then
     -e AWS_SESSION_TOKEN \
     -e SAM_STACK_NAME \
     -e TEST_ENVIRONMENT \
+    -e SHARED_STACK_NAME \
     acceptance-test-runner
 else
   npm run test:acceptance -- --format html:test-reports/acceptance.html

--- a/tests/acceptance/steps/utils/cloudformation.ts
+++ b/tests/acceptance/steps/utils/cloudformation.ts
@@ -2,7 +2,6 @@ import {
   CloudFormationClient,
   DescribeStacksCommand,
   DescribeStacksCommandOutput,
-  ListExportsCommand,
 } from "@aws-sdk/client-cloudformation";
 import { getString } from "../../../../src/types/string-utils";
 import { getSecret } from "@aws-lambda-powertools/parameters/secrets";
@@ -18,23 +17,6 @@ export const CloudFormationOutputs = {
 export type CloudFormationOutputsType = keyof typeof CloudFormationOutputs;
 
 const cloudFormationStacks: Map<string, DescribeStacksCommandOutput> = new Map();
-let cloudFormationExports: Map<string, string>;
-
-export const getCloudFormationExport = async (exportName: string): Promise<string> => {
-  if (!cloudFormationExports) {
-    const client = new CloudFormationClient();
-    cloudFormationExports = new Map(
-      (await client.send(new ListExportsCommand())).Exports?.map(({ Name, Value }) => [Name as string, Value as string])
-    );
-  }
-
-  const exportedValue = cloudFormationExports.get(exportName);
-  if (!exportedValue) {
-    throw new Error(`Export ${exportName} not found`);
-  }
-
-  return exportedValue;
-};
 
 export const getCloudFormationStack = async (stackName: string): Promise<DescribeStacksCommandOutput> => {
   let cloudFormationStack = cloudFormationStacks.get(stackName);


### PR DESCRIPTION
## Proposed changes

### What changed

Use SSM to pass the ARN of the API key secret to the acceptance tests.

The SSM parameter has been added to the shared stack template in https://github.com/govuk-one-login/ipv-identity-reuse-service-config/pull/17.

### Why did it change

The tests do not have the `cloudformation:ListExports` permission when running in the pipeline.

## Checklists

### Checklist for developers

- [x]  The PR description is filled out and the PR title includes the story reference
- [ ]  If there will be further PRs related to the story, this is highlighted in the PR description what is to come
- [x]  There are no merge, WIP or reversion commits included in the PR (reversion commits allowed if reverting previously merged code)
- [x]  All commits include story reference, a distinct title and a body listing changes
- [x]  All commits are signed
- [ ]  All commits contain a `Co-authored-by` line where pairing has taken place
- [x]  All changes in this PR are related to the story
- [x]  The changes have been fully tested in the dev environment
- [ ]  There are unit and/or integration tests matching story acceptance criteria (where applicable)
- [ ]  Any feature flags are correctly set for each target environment
- [ ]  Any related configuration changes have been merged and have landed in the target environment(s)
- [ ]  Any related platform changes have been merged and have been applied in the target environment(s)
- [ ]  This change will deploy with zero downtime (consider the blue/green nature of our deployments)
- [x]  Any Sonarcloud issues are addressed or dismissed with a valid reason
- [ ]  Any exceptions to any of the above statements are documented in the description and agreed with the reviewer

### Checklist for reviewers

- [ ]  The above statements are all true
- [ ]  The change meets the acceptance criteria set out in the story
- [ ]  There are no missing test scenarios
- [ ]  The code is readable and understandable
- [ ]  The code is maintainable and does not present any notable technical debt
- [ ]  There are no outstanding Sonarcloud issues, and you agree with any dismissal reasons

## Related PRs

https://github.com/govuk-one-login/ipv-identity-reuse-service-config/pull/17
https://github.com/govuk-one-login/ipv-trust-and-reuse-common-infra/pull/149