### PR TITLE
BAU: Updated dependabot to execute Monday 6am

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,18 +2,20 @@
 
 version: 2
 updates:
-  - package-ecosystem: 'npm'
-    directory: '/'
+  - package-ecosystem: "npm"
+    directory: "/"
     schedule:
-      interval: 'weekly'
+      interval: weekly
+      day: monday
+      time: "06:00"
     allow:
       - dependency-type: "direct"
     ignore:
       - dependency-name: "*"
-        update-types: [ "version-update:semver-patch" ]
+        update-types: ["version-update:semver-patch"]
     open-pull-requests-limit: 5
     pull-request-branch-name:
-      separator: '-'
+      separator: "-"
     groups:
       aws-dependencies:
         patterns:
@@ -43,6 +45,8 @@ updates:
     # Workflow files stored in the default location of `.github/workflows`
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: weekly
+      day: monday
+      time: "06:00"
     pull-request-branch-name:
-      separator: '-'
+      separator: "-"


### PR DESCRIPTION
## What

Updated dependabot to execute Monday 6am.

## Why

So that we have a regular Dependabot cadence and not sporadically throughout the week.