### PR TITLE
BAU: Added retry logic for consumer tests

### DIFF
--- a/src/tests/contract-tests/vitest.config.ts
+++ b/src/tests/contract-tests/vitest.config.ts
@@ -4,5 +4,10 @@ export default defineConfig({
   test: {
     projects: ["src/tests/contract-tests/consumer", "src/tests/contract-tests/provider"],
     bail: 1,
+    retry: {
+      // Retry to get around comms issues between PACT RUST server and JS client
+      count: 2,
+      delay: 50,
+    },
   },
 });


### PR DESCRIPTION
## Proposed changes

### What changed

Added retry logic for consumer tests

### Why did it change

This is due to communications issues that we have observed between the RUST PACT server and the PACT client. It appears that the PACT server handles the request, however the PACT client does not receive the expected response. We have compared the logs between a working test run and a failed test run and there are identical leading us to assume that there are comms issues.
