### PR TITLE
BAU: Downgraded PACT due to suspected bug

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]
+      - dependency-name: "@pact-foundation/pact"
+        versions: ["v16.4.0", "v16.3.1", "v16.3.0"]
     open-pull-requests-limit: 5
     pull-request-branch-name:
       separator: "-"

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "@cucumber/pretty-formatter": "3.3.0",
         "@eslint/eslintrc": "3.3.5",
         "@eslint/js": "10.0.1",
-        "@pact-foundation/pact": "16.3.0",
+        "@pact-foundation/pact": "16.2.0",
         "@types/aws-lambda": "8.10.161",
         "@types/cfn-response-promise": "1.1.4",
         "@types/express": "5.0.6",
@@ -2582,13 +2582,13 @@
       }
     },
     "node_modules/@pact-foundation/pact": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact/-/pact-16.3.0.tgz",
-      "integrity": "sha512-9SInfdwggCvkDZ1o4DZjF6uLpNUJ3JQm4tb3XPXT3ABGpu69lqJIAa6bgvMvZ2ktvMgH7FTeIU7KVJXHQ6l7Lg==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact/-/pact-16.2.0.tgz",
+      "integrity": "sha512-PFedoP49sR9EKEvhREsXiDTb+rS3yv016DIlufey6pXC6ssQKhgq78ngZDRGl7mc6PqLJdOBCZUDPUrR890k2A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pact-foundation/pact-core": "^19.1.0",
+        "@pact-foundation/pact-core": "^18.1.0",
         "axios": "^1.12.2",
         "body-parser": "^2.2.0",
         "chalk": "4.1.2",
@@ -2609,9 +2609,9 @@
       }
     },
     "node_modules/@pact-foundation/pact-core": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core/-/pact-core-19.1.0.tgz",
-      "integrity": "sha512-2jyns+jkgLZK79ovM3aMSYHaMyu6dWmwOQjykj0GUhs37G5jXPffSsmBR1fm//KSf244OvuyELrAsWC+FnUHgg==",
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core/-/pact-core-18.1.0.tgz",
+      "integrity": "sha512-QWdntTsTT32r3SOTDaKjB9QyEbbgfsshsY2X/OwBJaNq28jKYEw50t2lYrITN+SdhkgfkEZJ9Y0XNfxtOUDVnA==",
       "cpu": [
         "x64",
         "ia32",
@@ -2630,25 +2630,25 @@
         "node-gyp-build": "^4.6.0",
         "pino": "^10.0.0",
         "pino-pretty": "^13.1.1",
-        "underscore": "1.13.8"
+        "underscore": "1.13.7"
       },
       "engines": {
         "node": ">=20"
       },
       "optionalDependencies": {
-        "@pact-foundation/pact-core-darwin-arm64": "19.1.0",
-        "@pact-foundation/pact-core-darwin-x64": "19.1.0",
-        "@pact-foundation/pact-core-linux-arm64-glibc": "19.1.0",
-        "@pact-foundation/pact-core-linux-arm64-musl": "19.1.0",
-        "@pact-foundation/pact-core-linux-x64-glibc": "19.1.0",
-        "@pact-foundation/pact-core-linux-x64-musl": "19.1.0",
-        "@pact-foundation/pact-core-windows-x64": "19.1.0"
+        "@pact-foundation/pact-core-darwin-arm64": "18.1.0",
+        "@pact-foundation/pact-core-darwin-x64": "18.1.0",
+        "@pact-foundation/pact-core-linux-arm64-glibc": "18.1.0",
+        "@pact-foundation/pact-core-linux-arm64-musl": "18.1.0",
+        "@pact-foundation/pact-core-linux-x64-glibc": "18.1.0",
+        "@pact-foundation/pact-core-linux-x64-musl": "18.1.0",
+        "@pact-foundation/pact-core-windows-x64": "18.1.0"
       }
     },
     "node_modules/@pact-foundation/pact-core-darwin-arm64": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-darwin-arm64/-/pact-core-darwin-arm64-19.1.0.tgz",
-      "integrity": "sha512-bizRo7SawD6B3844QCR2Hap8Eh5qrrBSTZcRN6yLabD5KhIaIXWSXM/WaynT+f91Q9Up3GNF793/Vl3dxPf+3g==",
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-darwin-arm64/-/pact-core-darwin-arm64-18.1.0.tgz",
+      "integrity": "sha512-j1GSx7zN011xOveWeBP8RJ77bryFSLHIhe1ZcepfhMiB6VoUjGq1BNQ9rbhO4FSF2HBUCddMAw2/Xa+scHQJvQ==",
       "cpu": [
         "arm64"
       ],
@@ -2660,9 +2660,9 @@
       ]
     },
     "node_modules/@pact-foundation/pact-core-darwin-x64": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-darwin-x64/-/pact-core-darwin-x64-19.1.0.tgz",
-      "integrity": "sha512-au8ldd9XhRji1QNW/1Z/KVW4lfIFjrLwkDTbtJmliM83yNhvV+a3nhrOJcx11hmhnlGIT7otGLb9a5k1APWAMw==",
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-darwin-x64/-/pact-core-darwin-x64-18.1.0.tgz",
+      "integrity": "sha512-KV08M7WJm/uuXv2qES4s8oJw8uTgFjQXmHLq4tKGT8HkaYCuSoQAhWYafxBJ/sMHeZ1LoGfv4nJkUr8bNakCYg==",
       "cpu": [
         "x64"
       ],
@@ -2674,13 +2674,16 @@
       ]
     },
     "node_modules/@pact-foundation/pact-core-linux-arm64-glibc": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-linux-arm64-glibc/-/pact-core-linux-arm64-glibc-19.1.0.tgz",
-      "integrity": "sha512-1TBHpF8rOnukFUtTYyf7ULTT24FnYQlkSWYd+mN73uhrFX/irpxMgyJFAXBOoeI5VZTlSk1XuPy5WBK6SeMcEA==",
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-linux-arm64-glibc/-/pact-core-linux-arm64-glibc-18.1.0.tgz",
+      "integrity": "sha512-BeJqmtBR6IdOg2IU0Y+N1NsH1pzr5H3PeOJ+vTSgNiTnV/wYkKk6GZDT1dzwUVi+OjfarGbK86022EoHk/WpkQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2688,13 +2691,16 @@
       ]
     },
     "node_modules/@pact-foundation/pact-core-linux-arm64-musl": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-linux-arm64-musl/-/pact-core-linux-arm64-musl-19.1.0.tgz",
-      "integrity": "sha512-CvMbzjrCsxicVEd/yJ2vjiMTUsjFpgoC4lr8qL2lajLNEywDcumC9d+CtRbboauG8XqGRqxvH6tTrhO5nzZUPg==",
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-linux-arm64-musl/-/pact-core-linux-arm64-musl-18.1.0.tgz",
+      "integrity": "sha512-twakwextRNwkAKntYnSBBAs3yugORGDZwgihVm9p+eYqded/agFTu2v4/E7xksLEotGoFlewnAvLSCTvyNf0uw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2702,13 +2708,16 @@
       ]
     },
     "node_modules/@pact-foundation/pact-core-linux-x64-glibc": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-linux-x64-glibc/-/pact-core-linux-x64-glibc-19.1.0.tgz",
-      "integrity": "sha512-P+qwj65TpGRw+bn9//Eugpr98Hfab1zsOeCvj6SNIRr6VW3whCpojvESZXfISxuK+gP7KAXTbbG1gApbhwCQSA==",
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-linux-x64-glibc/-/pact-core-linux-x64-glibc-18.1.0.tgz",
+      "integrity": "sha512-rhR5iZS77Ie0ocJmtoTub82lyMQmjjn15UPhD5Tv1i2kYkbLCVPSYZpTrKak/OCDm5/AM0Lb7YqIZlOipMm/mA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2716,13 +2725,16 @@
       ]
     },
     "node_modules/@pact-foundation/pact-core-linux-x64-musl": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-linux-x64-musl/-/pact-core-linux-x64-musl-19.1.0.tgz",
-      "integrity": "sha512-SHYSGjznWj2rz3/ey6TqPdI9RezDVPkwszUF83Qc5iwuMRQgqcqgMEhjZaMS7mtGBX/tmLWqBgCHu/Z56EpBsQ==",
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-linux-x64-musl/-/pact-core-linux-x64-musl-18.1.0.tgz",
+      "integrity": "sha512-u0N5uU3hwupGCkSmIiehR4yw5Foln+qqkUWXjtKdnttsj8Dz065K8osNGy18jmPRWr5XfRZurnnmw0+tFyaZPA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2730,9 +2742,9 @@
       ]
     },
     "node_modules/@pact-foundation/pact-core-windows-x64": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-windows-x64/-/pact-core-windows-x64-19.1.0.tgz",
-      "integrity": "sha512-PIwNMO38QDCfd/h3Ys8i+1M1Yx7l+jf+oL3oxIPE1jby4CgY/MY2hoOH3VwFSYQhaOPHj1n7TpcW9EpbIkGdSA==",
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-windows-x64/-/pact-core-windows-x64-18.1.0.tgz",
+      "integrity": "sha512-ST7XNlI78c2MCvWvqv7on9M+DmNGlrihiD3Uk5jwZIAWEXeXEVinpfnM/Z5qFik4m3UCDe/Zu/1aNNiY1RN3dQ==",
       "cpu": [
         "x64"
       ],
@@ -5906,9 +5918,9 @@
       "license": "MIT"
     },
     "node_modules/fast-copy": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.2.tgz",
-      "integrity": "sha512-ybA6PDXIXOXivLJK/z9e+Otk7ve13I4ckBvGO5I2RRmBU1gMHLVDJYEuJYhGwez7YNlYji2M2DvVU+a9mSFDlw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.3.tgz",
+      "integrity": "sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==",
       "dev": true,
       "license": "MIT"
     },
@@ -9229,17 +9241,24 @@
       }
     },
     "node_modules/thread-stream": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.0.0.tgz",
-      "integrity": "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.1.0.tgz",
+      "integrity": "sha512-Bw6h2iBDt16v6iHLChBIoVYU8CBo9GPsW8TG7h1hRVhqKhIkH6N8qkxNSmiOZTKsCLPbtWG4ViWLkU6KeKXpig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "real-require": "^0.2.0"
+        "real-require": "^1.0.0"
       },
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/thread-stream/node_modules/real-require": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-1.0.0.tgz",
+      "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tiny-case": {
       "version": "1.0.3",
@@ -9491,9 +9510,9 @@
       }
     },
     "node_modules/underscore": {
-      "version": "1.13.8",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
-      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "version": "1.13.7",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
+      "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@cucumber/pretty-formatter": "3.3.0",
     "@eslint/eslintrc": "3.3.5",
     "@eslint/js": "10.0.1",
-    "@pact-foundation/pact": "16.3.0",
+    "@pact-foundation/pact": "16.2.0",
     "@types/aws-lambda": "8.10.161",
     "@types/cfn-response-promise": "1.1.4",
     "@types/express": "5.0.6",


### PR DESCRIPTION
## Proposed changes

### What changed

Downgraded PACT and prevented Dependabot from upgrading to all versions up to and including 16.4.0

### Why did it change

We suspect we're seeing pact failures due to the following bug report in PACT, see https://github.com/pact-foundation/pact-js/issues/1713. We are downgrading to an older version to see if this removes the number of failures we're experiencing as up until recently it was solid.
