### PR TITLE
BAU: Fix version of transitive dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@govuk-one-login/data-vocab": "2.0.2",
         "@types/aws-lambda": "8.10.161",
         "cfn-response-promise": "1.1.0",
-        "did-resolver": "4.1.0",
+        "did-resolver": "5.0.1",
         "esbuild": "0.28.0",
         "fast-glob": "3.3.3",
         "govuk-frontend": "6.1.0",
@@ -4202,9 +4202,9 @@
       }
     },
     "node_modules/did-resolver": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/did-resolver/-/did-resolver-4.1.0.tgz",
-      "integrity": "sha512-S6fWHvCXkZg2IhS4RcVHxwuyVejPR7c+a4Go0xbQ9ps5kILa8viiYQgrM4gfTyeTjJ0ekgJH9gk/BawTpmkbZA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/did-resolver/-/did-resolver-5.0.1.tgz",
+      "integrity": "sha512-AtbIfBt/D9Z6GeNKhm1AzCbF7y5PhsNukgmVYnsdxbIX8UAsquQpbm8ECfPwDRXAOM3EsGdHheK5WMojcPlAPg==",
       "license": "Apache-2.0"
     },
     "node_modules/diff": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@govuk-one-login/data-vocab": "2.0.2",
     "@types/aws-lambda": "8.10.161",
     "cfn-response-promise": "1.1.0",
-    "did-resolver": "4.1.0",
+    "did-resolver": "5.0.1",
     "esbuild": "0.28.0",
     "fast-glob": "3.3.3",
     "govuk-frontend": "6.1.0",
@@ -62,6 +62,11 @@
   "homepage": "https://github.com/govuk-one-login/ipv-identity-reuse-service#readme",
   "license": "MIT",
   "name": "ipv-identity-reuse-service",
+  "overrides": {
+    "web-did-resolver": {
+      "did-resolver": "$did-resolver"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/govuk-one-login/ipv-identity-reuse-service.git"


### PR DESCRIPTION

### What changed

-  Fix version of transitive dep which allows did-resolver to be updated


### Why did it change

- TypeScript incompatibility meant `did-resolver` couldn't be updated in an [earlier](https://github.com/govuk-one-login/ipv-identity-reuse-service/pull/311) Dependabot upgrade. This change fixes `web-did-resolver` which allows `did-resolver` to upgrade without errors. Note that the runtime of `did-resolver` didn't change, it was just the TypeScript types.

### Issue tracking

- BAU

## Testing
<!-- Please give an overview of how the changes were tested -->
<!-- Please specify if changes were tested locally and how, include evidence where relevant -->
<!-- Please specify if changes were deployed and tested in the AWS Account and how, include evidence where relevant -->
