### PR TITLE
SPT-1935: Ensure /authorize endpoint accepts JARs

### DIFF
--- a/openAPI/public-api.yaml
+++ b/openAPI/public-api.yaml
@@ -19,6 +19,7 @@ paths:
         - $ref: "#/components/parameters/RedirectUriParam"
         - $ref: "#/components/parameters/ScopeParam"
         - $ref: "#/components/parameters/StateParam"
+        - $ref: "#/components/parameters/RequestParam"
       responses:
         "302":
           $ref: "#/components/responses/AuthorizationRedirect"
@@ -164,6 +165,13 @@ components:
       required: true
       description: |
         The auth code.
+      schema:
+        type: string
+    RequestParam:
+      in: query
+      name: request
+      required: false
+      description: This value would be a JAR, passed in as a query parameter
       schema:
         type: string
   responses:

--- a/src/handlers/authorize-handler/authorize-handler.ts
+++ b/src/handlers/authorize-handler/authorize-handler.ts
@@ -13,6 +13,7 @@ export type AuthorizationQueryStringParameters = {
   redirect_uri: string;
   scope?: string;
   state: string;
+  request?: string;
 };
 
 export const handler = async (event: APIGatewayProxyEvent, context: Context): Promise<APIGatewayProxyResult> => {

--- a/src/handlers/authorize-handler/tests/authorize-handler.test.ts
+++ b/src/handlers/authorize-handler/tests/authorize-handler.test.ts
@@ -11,6 +11,7 @@ it("should return 302 status code on a successful request", async () => {
       response_type: "code",
       redirect_uri: "https://api.example.com/callback",
       state: "test-state",
+      request: "test.1234.5678",
     } satisfies AuthorizationQueryStringParameters,
   });
 


### PR DESCRIPTION
## Proposed changes

### What changed
Added an optional request parameter to the `/authorize` endpoint OpenAPI definition.

### Why did it change
This change will allow the `/authorize` endpoint to accept JARs by making the request query parameter on the endpoint optional for now.

### Issue tracking
[SPT-1935](https://govukverify.atlassian.net/browse/SPT-1935)

## Testing
Deployed to dev and all unit and acceptance tests passing.

## Checklists

### Checklist for developers

- [x]  The PR description is filled out and the PR title includes the story reference
- [ ]  If there will be further PRs related to the story, this is highlighted in the PR description what is to come
- [x]  There are no merge, WIP or reversion commits included in the PR (reversion commits allowed if reverting previously merged code)
- [x]  All commits include story reference, a distinct title and a body listing changes
- [x]  All commits are signed
- [ ]  All commits contain a `Co-authored-by` line where pairing has taken place
- [x]  All changes in this PR are related to the story
- [x]  The changes have been fully tested in the dev environment
- [ ]  There are unit and/or integration tests matching story acceptance criteria (where applicable)
- [ ]  Any feature flags are correctly set for each target environment
- [ ]  Any related configuration changes have been merged and have landed in the target environment(s)
- [ ]  Any related platform changes have been merged and have been applied in the target environment(s)
- [ ]  This change will deploy with zero downtime (consider the blue/green nature of our deployments)
- [ ]  Any Sonarcloud issues are addressed or dismissed with a valid reason
- [ ]  Any exceptions to any of the above statements are documented in the description and agreed with the reviewer

### Checklist for reviewers

- [ ]  The above statements are all true
- [ ]  The change meets the acceptance criteria set out in the story
- [ ]  There are no missing test scenarios
- [ ]  The code is readable and understandable
- [ ]  The code is maintainable and does not present any notable technical debt
- [ ]  There are no outstanding Sonarcloud issues, and you agree with any dismissal reasons


[SPT-1935]: https://govukverify.atlassian.net/browse/SPT-1935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ