### PR TITLE
BAU: Use correct parameters for GitHub workflow

### DIFF
--- a/.github/workflows/delete-deployment.yaml
+++ b/.github/workflows/delete-deployment.yaml
@@ -93,6 +93,7 @@ jobs:
               "channel_id": "${{ secrets.ERROR_SLACK_WEBHOOK_CHANNEL_ID }}",
               "github_repo": "${{ github.repository }}",
               "message": "Delete ipv-identity-reuse-service deployment ${{ github.actor }} has failed.",
-              "aws_account": "N/A",
-              "level": "ERROR"
+              "level": "ERROR",
+              "logs": "${{ github.event.workflow_run.html_url }}",
+              "workflow_name": "${{ github.event.workflow.name }}"
             }


### PR DESCRIPTION
### What changed
<!-- Describe the changes in detail - the "what"-->
<!-- Include all information the reviewer needs for context -->

Change the parameters in the body of the request to our "build failure" Slack webhook to match what the workflow expects.

* Remove `aws_account` (not used by the workflow)
* Add `logs` and `workflow_name` (used by the workflow)

<img width="837" height="501" alt="Screenshot 2026-06-04 at 09 56 56" src="https://github.com/user-attachments/assets/fb29372f-dabe-4257-9faf-11a1b6c24cff" />

### Why did it change
<!-- Describe the reason these changes were made - the "why" -->
<!-- Include all information the reviewer needs for context -->

I keep seeing notifications that a Slack workflow has failed.

<img width="466" height="475" alt="Screenshot 2026-06-04 at 09 05 47" src="https://github.com/user-attachments/assets/54e70fd3-13b2-4798-b101-e74deaed1f10" />

The activity logs say:

> `Send a message to a channel failed to start due to an invalid parameter. Please check the configuration for this step or report the issue to Slack.`

I have a hypothesis that the Slack workflow fails when triggered by the [delete deployment GitHub workflow failing](https://github.com/govuk-one-login/ipv-identity-reuse-service/actions/workflows/delete-deployment.yaml).

The aim of this PR is to test if this fixes the issue. I will rerun one of the failing workflow runs after merge to validate the hypothesis.

NOTE that if this does fix it, I will follow up with another PR to remove the `Notify on failure` step from this delete-deployment job, and add it as a workflow in the [error-handler workflow](https://github.com/govuk-one-login/ipv-identity-reuse-service/blob/main/.github/workflows/error-handler.yaml) instead, which will allow us to deduplicate some code. But for now I want to do this small change to prove the hypothesis.

Investigating why the `delete-deployment` workflow is failing is out of scope for this PR, and will be picked up separately.