### PR TITLE
BAU: error-handler workflow should trigger when delete-deployment fails

### DIFF
--- a/.github/workflows/delete-deployment.yaml
+++ b/.github/workflows/delete-deployment.yaml
@@ -80,20 +80,3 @@ jobs:
         with:
           stack-names: ${{ env.STACKS_TO_DELETE }}
           aws-region: ${{ env.AWS_REGION }}
-
-      - name: Notify on failure
-        if: ${{ failure() && endsWith(github.ref, 'main') }}
-        id: slack
-        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # pin@v3.0.3
-        with:
-          webhook-type: incoming-webhook
-          webhook: ${{ secrets.ERROR_SLACK_WEBHOOK }}
-          payload: |
-            {
-              "channel_id": "${{ secrets.ERROR_SLACK_WEBHOOK_CHANNEL_ID }}",
-              "github_repo": "${{ github.repository }}",
-              "message": "Delete ipv-identity-reuse-service deployment ${{ github.actor }} has failed.",
-              "level": "ERROR",
-              "logs": "${{ github.event.workflow_run.html_url }}",
-              "workflow_name": "${{ github.event.workflow.name }}"
-            }

--- a/.github/workflows/error-handler.yaml
+++ b/.github/workflows/error-handler.yaml
@@ -5,6 +5,7 @@ on:
     workflows:
       - acceptance-tests
       - build
+      - delete-deployment
       - deploy-to-aws
       - pact-tests
       - post-merge


### PR DESCRIPTION
### What changed
<!-- Describe the changes in detail - the "what"-->
<!-- Include all information the reviewer needs for context -->

Currently the delete-deployment job has it's own "notify on failure" step, but this code now lives in the error-handler workflow as a shared on-error workflow. This commit removes the duplicate code from delete-deployment and configures error-handler to trigger if delete-deployment fails.

### Why did it change
<!-- Describe the reason these changes were made - the "why" -->
<!-- Include all information the reviewer needs for context -->

It is also believed that this will fix an issue where the Slack workflow expects parameters that are set within error-handler. The delete-deployment version is currently sending blank values probably due to the way it is triggered.

<img width="727" height="296" alt="Screenshot 2026-06-04 at 11 55 54" src="https://github.com/user-attachments/assets/a9ab0c5d-af25-4184-bbad-46344a305d3b" />
