### PR TITLE
BAU: Update name of delete-deployment workflow

### DIFF
--- a/.github/workflows/delete-deployment.yaml
+++ b/.github/workflows/delete-deployment.yaml
@@ -1,5 +1,4 @@
-name: Delete deployment
-
+name: delete-deployment
 
 on:
   schedule:


### PR DESCRIPTION
### What changed
<!-- Describe the changes in detail - the "what"-->
<!-- Include all information the reviewer needs for context -->

Previously the workflow file for delete-deployment.yaml had a name value "Delete deployment", which did not match the name used to reference this workflow from the error-handler workflow. This uses snake case as it is more consistent with other workflow names.

### Why did it change
<!-- Describe the reason these changes were made - the "why" -->
<!-- Include all information the reviewer needs for context -->

Fixes previous PR https://github.com/govuk-one-login/ipv-identity-reuse-service/pull/326 - the error-handler wasn't being triggered correctly as the name did not match the file name (which I assumed it did).