### PR TITLE
BAU: Ensure the ConfirmDetailsLambda includes the Dynatrace layer

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1157,6 +1157,10 @@ Resources:
           NODE_OPTIONS: "--enable-source-maps"
       Layers:
         - !Ref GovUKFrontEndLayer
+        - !If
+          - DynaTraceEnabled
+          - !Ref DynatraceNodeLayerArn
+          - !Ref AWS::NoValue
     Metadata:
       BuildMethod: makefile
 


### PR DESCRIPTION
### What changed
<!-- Describe the changes in detail - the "what"-->
<!-- Include all information the reviewer needs for context -->

Ensure the ConfirmDetailsLambda includes the Dynatrace layer when Dynatrace is enabled.

### Why did it change
<!-- Describe the reason these changes were made - the "why" -->
<!-- Include all information the reviewer needs for context -->

Currently the absence of this layer is causing errors in the Build environment because Dynatrace is enabled but the layer is not available to this lambda function.

Using the [Orch stub in Build](https://orch.reuse.dev.stubs.account.gov.uk/) returns an internal error when redirected to the SIS /confirm-details page.