### PR TITLE
SPT-1947: Remove DrivingLicenceExpiryCheck flag

### DIFF
--- a/src/commons/configuration.ts
+++ b/src/commons/configuration.ts
@@ -9,7 +9,6 @@ export type Configuration = {
   fraudIssuer: string[];
   fraudValidityPeriod: number;
   controllerAllowList: string[];
-  enableDrivingLicenceExpiryCheck?: boolean;
   drivingLicenceValidityPeriod?: number;
   dcmawIssuer?: string[];
 };

--- a/src/identity-reuse/identity-expiry-service.ts
+++ b/src/identity-reuse/identity-expiry-service.ts
@@ -8,11 +8,7 @@ export const hasIdentityExpired = (currentVcs: VerifiableCredentialJWT[], config
   const fraudExpired = hasFraudCheckExpired(fraudVc, configuration.fraudValidityPeriod);
 
   let drivingLicenceExpired: boolean | undefined = undefined;
-  if (
-    configuration.enableDrivingLicenceExpiryCheck &&
-    configuration.dcmawIssuer !== undefined &&
-    configuration.drivingLicenceValidityPeriod !== undefined
-  ) {
+  if (configuration.dcmawIssuer !== undefined && configuration.drivingLicenceValidityPeriod !== undefined) {
     drivingLicenceExpired = hasDrivingLicenceExpired(
       currentVcs,
       configuration.dcmawIssuer,

--- a/src/identity-reuse/tests/identity-expiry-service.test.ts
+++ b/src/identity-reuse/tests/identity-expiry-service.test.ts
@@ -16,7 +16,6 @@ const BASE_CONFIGURATION: Configuration = {
   fraudIssuer: FRAUD_ISSUER,
   fraudValidityPeriod: 180,
   controllerAllowList: [],
-  enableDrivingLicenceExpiryCheck: true,
   dcmawIssuer: DCMAW_ISSUER,
   drivingLicenceValidityPeriod: 180,
 };
@@ -72,17 +71,6 @@ describe("identity-expiry-service", () => {
 
     const result = hasIdentityExpired([createMockVc("fraudCRI")], BASE_CONFIGURATION);
     expect(result).toBe(false);
-  });
-
-  it("should not check driving licence expiry when feature flag is disabled", () => {
-    vi.spyOn(fraudCheckService, "hasFraudCheckExpired").mockReturnValue(false);
-    const mockDlCheck = vi.spyOn(drivingLicenceExpiryService, "hasDrivingLicenceExpired");
-
-    const configuration = { ...BASE_CONFIGURATION, enableDrivingLicenceExpiryCheck: false };
-    const result = hasIdentityExpired([createMockVc("fraudCRI")], configuration);
-
-    expect(result).toBe(false);
-    expect(mockDlCheck).not.toHaveBeenCalled();
   });
 
   it("should not check driving licence expiry when dcmawIssuer is undefined", () => {


### PR DESCRIPTION
## Proposed changes

### What changed
Removed the `enableDrivingLicenceExpiryCheck` feature flag and its references

### Why did it change
Feature flag needs to be removed after go-live.

### Issue tracking
- [SPT-1947](https://govukverify.atlassian.net/browse/SPT-1947)

## Testing
All tests passing.

## Related PRs
SIS Config: https://github.com/govuk-one-login/ipv-identity-reuse-service-config/pull/142

## Checklists

### Checklist for developers

- [x]  The PR description is filled out and the PR title includes the story reference
- [x]  If there will be further PRs related to the story, this is highlighted in the PR description what is to come
- [x]  There are no merge, WIP or reversion commits included in the PR (reversion commits allowed if reverting previously merged code)
- [x]  All commits include story reference, a distinct title and a body listing changes
- [x]  All commits are signed
- [ ]  All commits contain a `Co-authored-by` line where pairing has taken place
- [x]  All changes in this PR are related to the story
- [x]  The changes have been fully tested in the dev environment
- [ ]  There are unit and/or integration tests matching story acceptance criteria (where applicable)
- [ ]  Any feature flags are correctly set for each target environment
- [ ]  Any related configuration changes have been merged and have landed in the target environment(s)
- [ ]  Any related platform changes have been merged and have been applied in the target environment(s)
- [ ]  This change will deploy with zero downtime (consider the blue/green nature of our deployments)
- [ ]  Any Sonarcloud issues are addressed or dismissed with a valid reason
- [ ]  Any exceptions to any of the above statements are documented in the description and agreed with the reviewer

### Checklist for reviewers

- [ ]  The above statements are all true
- [ ]  The change meets the acceptance criteria set out in the story
- [ ]  There are no missing test scenarios
- [ ]  The code is readable and understandable
- [ ]  The code is maintainable and does not present any notable technical debt
- [ ]  There are no outstanding Sonarcloud issues, and you agree with any dismissal reasons


[SPT-1947]: https://govukverify.atlassian.net/browse/SPT-1947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ