### PR TITLE
SPT-1954: Change URL to token generator

### DIFF
--- a/src/handlers/user-identity/tests/user-identity-handler.test.ts
+++ b/src/handlers/user-identity/tests/user-identity-handler.test.ts
@@ -34,7 +34,7 @@ const event = () => {
   return {
     headers: {
       accept: "*/*",
-      Host: "stack-name.credential-store.dev.account.gov.uk",
+      Host: "stack-name.token-generator.dev.account.gov.uk",
       "X-Amzn-Trace-Id": "Root=1-666bf197-43c06e88748f092a5cc812a9",
       "x-api-key": "a-pretend-api-key-value",
       "X-Forwarded-For": "123.123.123.123",

--- a/tests/acceptance/steps/utils/get-bearer-token.ts
+++ b/tests/acceptance/steps/utils/get-bearer-token.ts
@@ -1,7 +1,7 @@
 const getMockCredentialStorePath = () => {
   return process.env.ENVIRONMENT === "local" || process.env.ENVIRONMENT === "dev"
-    ? "credential-store.reuse.dev.stubs.account.gov.uk"
-    : "credential-store.reuse.stubs.account.gov.uk";
+    ? "token-generator.reuse.dev.stubs.account.gov.uk"
+    : "token-generator.reuse.stubs.account.gov.uk";
 };
 
 export const getBearerToken = async (sub: string): Promise<string> => {


### PR DESCRIPTION
## Proposed changes

### What changed

The stub token generator has changed URLs to remove reference to "credential-store", which was causing confusion.

The new URL is `https://token-generator.reuse.dev.stubs.account.gov.uk`.

### Why did it change

To prevent confusion in (until now) similarly named `aud` and `iss` fields.

## Related PRs

https://github.com/govuk-one-login/ipv-reuse-service-stubs/pull/300
https://github.com/govuk-one-login/ipv-trust-and-reuse-common-infra/pull/215