### PR TITLE
SPT-1934: Added /.well-known/jwks.json endpoint

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -143,7 +143,7 @@
         "filename": "template.yaml",
         "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
         "is_verified": false,
-        "line_number": 130,
+        "line_number": 135,
         "is_secret": false
       },
       {
@@ -151,7 +151,7 @@
         "filename": "template.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
         "is_verified": false,
-        "line_number": 195,
+        "line_number": 200,
         "is_secret": false
       },
       {
@@ -159,7 +159,7 @@
         "filename": "template.yaml",
         "hashed_secret": "aa1dd0ad4d2da161dd67db89e3d1aff921426385",
         "is_verified": false,
-        "line_number": 281,
+        "line_number": 286,
         "is_secret": false
       },
       {
@@ -167,7 +167,7 @@
         "filename": "template.yaml",
         "hashed_secret": "5f784906cd85d6336c8506e9da9d102405771429",
         "is_verified": false,
-        "line_number": 287,
+        "line_number": 292,
         "is_secret": false
       },
       {
@@ -175,7 +175,7 @@
         "filename": "template.yaml",
         "hashed_secret": "1ef0d2ac7a97bfe12f63f5d79979f912500adae1",
         "is_verified": false,
-        "line_number": 293,
+        "line_number": 298,
         "is_secret": false
       },
       {
@@ -183,7 +183,7 @@
         "filename": "template.yaml",
         "hashed_secret": "5f399dc88587898510cf56b7503b482c870d0121",
         "is_verified": false,
-        "line_number": 299,
+        "line_number": 304,
         "is_secret": false
       },
       {
@@ -191,10 +191,10 @@
         "filename": "template.yaml",
         "hashed_secret": "dc2050b23f4157e1b630f2bdf2f0a76b82f0f51a",
         "is_verified": false,
-        "line_number": 305,
+        "line_number": 310,
         "is_secret": false
       }
     ]
   },
-  "generated_at": "2026-04-30T16:45:18Z"
+  "generated_at": "2026-06-12T12:37:06Z"
 }

--- a/openAPI/public-api.yaml
+++ b/openAPI/public-api.yaml
@@ -5,6 +5,40 @@ info:
   description: "Public API for the Stored Identity Service"
   version: "1.0.0"
 paths:
+  /.well-known/jwks.json:
+    get:
+      responses:
+        "200":
+          description: OK
+          headers:
+            Cache-Control:
+              type: string
+          content:
+            application/jwks+json:
+              schema:
+                type: object
+        "404":
+          description: Not Found
+      x-amazon-apigateway-integration:
+        credentials:
+          Fn::GetAtt: RestOAuthDocumentResourceS3Role.Arn
+        uri:
+          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:s3:path/govuk-one-login-${ServiceName}-published-keys-${Environment}/jwks.json"
+        passthroughBehavior: WHEN_NO_MATCH
+        httpMethod: GET
+        type: aws
+        responses:
+          "200":
+            statusCode: "200"
+            responseParameters:
+              method.response.header.Cache-Control: "'max-age=3600, private'"
+          "404":
+            statusCode: "404"
+            responseTemplates:
+              application/json: |
+                {
+                    "message": "Not Found"
+                }
   /authorize:
     get:
       summary: Get an authorization grant

--- a/template.yaml
+++ b/template.yaml
@@ -51,6 +51,11 @@ Parameters:
     Type: String
     Default: GOV.UK One Login
 
+  ServiceName:
+    Description: Service name
+    Type: String
+    Default: sis
+
   SourceTagValue:
     Description: Value for the Source Tag
     Type: String
@@ -1177,6 +1182,7 @@ Resources:
     Metadata:
       BuildMethod: esbuild
       BuildProperties:
+        UseNpmCi: True
         EntryPoints:
           - src/handlers/confirm-details/confirm-details-submission-handler.ts
         Target: es2022
@@ -2669,6 +2675,39 @@ Resources:
       AlarmActions:
         - !ImportValue alerting-integration-AlertNotificationTopicArn
       TreatMissingData: notBreaching
+
+  ##########################
+  # .well-known resources
+  ##########################
+  RestOAuthDocumentResourceS3Role:
+    Type: AWS::IAM::Role
+    Properties:
+      PermissionsBoundary: !If
+        - UsePermissionsBoundary
+        - !Ref PermissionsBoundary
+        - !Ref AWS::NoValue
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: apigateway.amazonaws.com
+      Policies:
+        - PolicyName: AccessOAuthS3Document
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "s3:GetObject"
+                  - "s3:ListBucket"
+                Resource:
+                  - !Sub "arn:aws:s3:::govuk-one-login-${ServiceName}-published-keys-${Environment}"
+                  - !Sub "arn:aws:s3:::govuk-one-login-${ServiceName}-published-keys-${Environment}/jwks.json"
+      Tags:
+        - Key: "key_consumer_type"
+          Value: "use"
 
   ########
   # KEYS #


### PR DESCRIPTION
## Proposed changes

### What changed

Added GET /.well-known/jwks.json endpoint which reads the jwks.json from the `govuk-one-login-sis-published-keys-<env>` S3 bucket. This includes the following changes:

* Added `ServiceName` property configured to `sis` by default, so that the name of the bucket can be obtained.
* Added the `/.well-known/jwks.json` to the public API specification.
* Added the `RestOAuthDocumentResourceS3Role` resource with the `key_consumer_type` tag set to `use` so that it can read the jwks.json file from the s3 bucket.

### Why did it change

So that the OAuth workflow can obtain the `jwks.json` document.

## Testing

### Manual Steps to Test

Deployed to https://preview-pr-338.reuse-identity.dev.account.gov.uk/.well-known/jwks.json
