### PR TITLE
SPT-1916: Create error page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,14 @@ build-ConfirmDetailsLambda:
 		--external:govuk-frontend \
 		--outdir=$(ARTIFACTS_DIR)
 	cp src/handlers/confirm-details/*.njk $(ARTIFACTS_DIR)/
+
+build-UnrecoverableErrorLambda:
+	./node_modules/.bin/esbuild src/handlers/unrecoverable-error/unrecoverable-error-handler.ts \
+		--bundle \
+		--platform=node \
+		--target=es2022 \
+		--minify \
+		--sourcemap \
+		--external:govuk-frontend \
+		--outdir=$(ARTIFACTS_DIR)
+	cp src/handlers/unrecoverable-error/*.njk $(ARTIFACTS_DIR)/

--- a/openAPI/public-api.yaml
+++ b/openAPI/public-api.yaml
@@ -107,6 +107,22 @@ paths:
         credentials:
           Fn::GetAtt: ConfirmDetailsLambdaRestApiRole.Arn
         type: aws_proxy
+  /error/unrecoverable:
+    get:
+      responses:
+        "200":
+          description: OK
+          content:
+            text/html:
+              schema:
+                type: string
+      x-amazon-apigateway-integration:
+        httpMethod: POST
+        uri:
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${UnrecoverableErrorLambda.Arn}:live/invocations
+        credentials:
+          Fn::GetAtt: UnrecoverableErrorLambdaRestApiRole.Arn
+        type: aws_proxy
   /{item+}:
     get:
       parameters:

--- a/src/handlers/unrecoverable-error/index.njk
+++ b/src/handlers/unrecoverable-error/index.njk
@@ -1,0 +1,42 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+
+{% extends "govuk/template.njk" %}
+{% block head %}
+    <link rel="stylesheet" href="{{ rootPath | default("", true) }}/govuk-frontend.min.css">
+    <base href="./error/unrecoverable" />
+{% endblock %}
+{% block content %}
+    {% if errors and errors.length > 0 %}
+        {{ govukErrorSummary({
+            "titleText": "Error",
+            "errorList":  errors
+        }) }}
+    {% endif %}
+
+    <h1 class="govuk-heading-l">Sorry, there is a problem</h1>
+    <p class="govuk-body">We cannot confirm your identity right now.</p>
+    <h2 class="govuk-heading-m">What you can do</h2>
+    <p class="govuk-body">Go back to the service you were trying to use and start again. You can look for
+    the service using your search engine or find it from the GOV.UK homepage.</p>
+
+    {{ govukButton({
+        "text": "Go to the GOV.UK homepage",
+        "type": "Submit",
+        "href": "https://www.gov.uk/"
+      }) }}
+
+    <p class="govuk-body">
+      <a href="https://home.build.account.gov.uk/contact-gov-uk-one-login?fromUrl=https%3A%2F%2Fidentity.build.account.gov.uk%2Fdev%2Ftemplate%2Fpyi-technical%2Fen%3FisUnrecoverable%3D" target="_blank" rel="noopener noreferrer" class="govuk-link">Contact the GOV.UK One Login team (opens in a new tab)</a>
+    </p>
+{% endblock %}
+
+{% block bodyEnd %}
+{# Run JavaScript at end of the <body>, to avoid blocking the initial render. #}
+<script type="module" src="{{ rootPath | default("", true) }}/govuk-frontend.min.js"></script>
+<script type="module">
+    import { initAll } from '{{ rootPath | default("", true) }}/govuk-frontend.min.js'
+    initAll()
+</script>
+{% endblock %}

--- a/src/handlers/unrecoverable-error/tests/unrecoverable-error-handler.test.ts
+++ b/src/handlers/unrecoverable-error/tests/unrecoverable-error-handler.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, expect, it, vitest } from "vitest";
+import { lambdaHandler } from "../unrecoverable-error-handler";
+
+const { mockRender } = vitest.hoisted(() => {
+  return {
+    mockRender: vitest.fn().mockReturnValue("Rendered Unrecoverable Error Screen"),
+  };
+});
+
+vitest.mock("nunjucks", () => {
+  return {
+    default: {
+      configure: vitest.fn().mockImplementation(() => ({
+        render: mockRender,
+      })),
+    },
+    configure: vitest.fn().mockImplementation(() => ({
+      render: mockRender,
+    })),
+  };
+});
+
+afterEach(() => {
+  vitest.clearAllMocks();
+});
+
+it("should render the error screen", async () => {
+  const result = await lambdaHandler();
+
+  expect(mockRender).toHaveBeenCalledExactlyOnceWith("index.njk", {
+    assetPath: "/assets",
+    rootPath: "",
+  });
+
+  expect(result).toEqual({
+    body: "Rendered Unrecoverable Error Screen",
+    headers: {
+      "content-type": "text/html",
+    },
+    statusCode: 200,
+  });
+});
+
+it("should catch unexpected errors and return a 500 status code", async () => {
+  mockRender.mockImplementation(() => {
+    throw new Error("Forced rendering error");
+  });
+
+  const response = await lambdaHandler();
+
+  expect(response.statusCode).toBe(500);
+  expect(response.body).toContain("");
+  expect(mockRender).toHaveBeenCalled();
+});

--- a/src/handlers/unrecoverable-error/unrecoverable-error-handler.ts
+++ b/src/handlers/unrecoverable-error/unrecoverable-error-handler.ts
@@ -1,0 +1,28 @@
+import { APIGatewayProxyResult } from "aws-lambda";
+import nunjucks from "nunjucks";
+import path from "node:path";
+import logger from "../../commons/logger";
+
+const govukFrontendDistribution = path.join(path.dirname(require.resolve("govuk-frontend/package.json")), "dist");
+const nunjucksEnvironment = nunjucks.configure([__dirname, govukFrontendDistribution]);
+
+export const lambdaHandler = async (): Promise<APIGatewayProxyResult> => {
+  try {
+    return {
+      statusCode: 200,
+      body: nunjucksEnvironment.render("index.njk", {
+        assetPath: "/assets",
+        rootPath: "",
+      }),
+      headers: {
+        "content-type": "text/html",
+      },
+    };
+  } catch (error) {
+    logger.error(`Error in lambdaHandler event: ${error}`);
+    return {
+      statusCode: 500,
+      body: "",
+    };
+  }
+};

--- a/template.yaml
+++ b/template.yaml
@@ -1275,6 +1275,110 @@ Resources:
         - Key: Name
           Value: !Sub "/aws/lambda/${ConfirmDetailsSubmissionLambda}"
 
+  UnrecoverableErrorRole:
+    # checkov:skip=CKV_AWS_111: Ensure IAM policies does not allow write access without constraints
+    Type: AWS::IAM::Role
+    Condition: IsNotProduction
+    Properties:
+      PermissionsBoundary: !If
+        - UsePermissionsBoundary
+        - !Ref PermissionsBoundary
+        - !Ref AWS::NoValue
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action:
+              - "sts:AssumeRole"
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+
+  UnrecoverableErrorLambda:
+    Type: AWS::Serverless::Function
+    Condition: IsNotProduction
+    Properties:
+      FunctionName: !Sub "${AWS::StackName}-UnrecoverableErrorLambda"
+      Handler: unrecoverable-error-handler.lambdaHandler
+      Role: !GetAtt UnrecoverableErrorRole.Arn
+      Environment:
+        Variables:
+          NODE_OPTIONS: "--enable-source-maps"
+      Layers:
+        - !Ref GovUKFrontEndLayer
+        - !If
+          - DynaTraceEnabled
+          - !Ref DynatraceNodeLayerArn
+          - !Ref AWS::NoValue
+    Metadata:
+      BuildMethod: makefile
+
+  UnrecoverableErrorLambdaRestApiRole:
+    Type: AWS::IAM::Role
+    Condition: IsNotProduction
+    Properties:
+      RoleName: !Sub "${AWS::StackName}-UnrecoverableErrorLambdaRestApiRole"
+      Description: !Sub "Role for the UnrecoverableErrorLambda"
+      PermissionsBoundary: !If [ UsePermissionsBoundary, !Ref PermissionsBoundary, !Ref AWS::NoValue ]
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: apigateway.amazonaws.com
+            Action:
+              - "sts:AssumeRole"
+      Tags:
+        - Key: Product
+          Value: !Ref ProductTagValue
+        - Key: System
+          Value: !Ref SystemTagValue
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: Owner
+          Value: !Ref OwnerTagValue
+        - Key: Source
+          Value: !Ref SourceTagValue
+
+  UnrecoverableErrorLambdaRestApiPolicy:
+    Type: AWS::IAM::Policy
+    Condition: IsNotProduction
+    Properties:
+      PolicyName: !Sub "${AWS::StackName}-UnrecoverableErrorLambdaRestApiPolicy"
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: "Allow"
+            Action:
+              - "lambda:InvokeFunction"
+            Resource:
+              - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${AWS::StackName}-UnrecoverableErrorLambda:*"
+      Roles:
+        - !Ref UnrecoverableErrorLambdaRestApiRole
+
+  UnrecoverableErrorFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Condition: IsNotProduction
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${UnrecoverableErrorLambda}"
+      RetentionInDays: 30
+      KmsKeyId: !GetAtt CloudWatchEncryptionKey.Arn
+      Tags:
+        - Key: Product
+          Value: !Ref ProductTagValue
+        - Key: System
+          Value: !Ref SystemTagValue
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: Owner
+          Value: !Ref OwnerTagValue
+        - Key: Source
+          Value: !Ref SourceTagValue
+        - Key: Name
+          Value: !Sub "/aws/lambda/${UnrecoverableErrorLambda}"
+
   ################################
   # PRIVATE API API GATEWAY       #
   ################################


### PR DESCRIPTION
## Proposed changes

### What changed
- Created a new front end error page in SIS
- Renamed existing AWS resources to be shared between the front end related components

### Why did it change
As part of the implementation of a front-end for SIS Phase 3, an error page is required to route a user to when they encounter a problem.

### Issue tracking
[SPT-1916](https://govukverify.atlassian.net/browse/SPT-1916)

## Testing
Tested in the dev environment: https://preview-pr-340.reuse-identity.dev.account.gov.uk/error/unrecoverable

## Checklists

### Checklist for developers

- [x]  The PR description is filled out and the PR title includes the story reference
- [ ]  If there will be further PRs related to the story, this is highlighted in the PR description what is to come
- [x]  There are no merge, WIP or reversion commits included in the PR (reversion commits allowed if reverting previously merged code)
- [x]  All commits include story reference, a distinct title and a body listing changes
- [x]  All commits are signed
- [ ]  All commits contain a `Co-authored-by` line where pairing has taken place
- [x]  All changes in this PR are related to the story
- [x]  The changes have been fully tested in the dev environment
- [x]  There are unit and/or integration tests matching story acceptance criteria (where applicable)
- [ ]  Any feature flags are correctly set for each target environment
- [ ]  Any related configuration changes have been merged and have landed in the target environment(s)
- [ ]  Any related platform changes have been merged and have been applied in the target environment(s)
- [ ]  This change will deploy with zero downtime (consider the blue/green nature of our deployments)
- [ ]  Any Sonarcloud issues are addressed or dismissed with a valid reason
- [ ]  Any exceptions to any of the above statements are documented in the description and agreed with the reviewer

### Checklist for reviewers

- [ ]  The above statements are all true
- [ ]  The change meets the acceptance criteria set out in the story
- [ ]  There are no missing test scenarios
- [ ]  The code is readable and understandable
- [ ]  The code is maintainable and does not present any notable technical debt
- [ ]  There are no outstanding Sonarcloud issues, and you agree with any dismissal reasons


[SPT-1916]: https://govukverify.atlassian.net/browse/SPT-1916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ