### PR TITLE
SPT-1933: Export details of the audit queue from the main SIS stack

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -2883,6 +2883,24 @@ Outputs:
     Description: App Config environment - used for testing.
     Value: !Ref Environment
 
+  AuditEventQueueEncryptionKeyArn:
+    Description: The ARN for the key used to encrypt/decrypt audit messages on the audit queue
+    Value: !GetAtt AuditEventQueueEncryptionKey.Arn
+    Export:
+      Name: !Sub ${AWS::StackName}-AuditEventQueueEncryptionKeyArn
+
+  AuditEventQueueName:
+    Description: The name of the queue where audit messages are sent
+    Value: !GetAtt AuditEventQueue.QueueName
+    Export:
+      Name: !Sub ${AWS::StackName}-AuditEventQueueName
+
+  AuditEventQueueUrl:
+    Description: The url of the queue where audit messages are sent
+    Value: !Ref AuditEventQueue
+    Export:
+      Name: !Sub ${AWS::StackName}-AuditEventQueueUrl
+
   SisPublicApi:
     Condition: IsNotProduction
     Description: "URL for the Stored Identity Service Public API"


### PR DESCRIPTION
## Proposed changes
<!-- Include the Jira ticket number in square brackets as prefix, eg `SPT-XXXX: Description of Change` -->

### What changed
<!-- Describe the changes in detail - the "what"-->
<!-- Include all information the reviewer needs for context -->

This commit configures the SIS template to output the parameters that will be imported by the OAuth Common stack when it is deployed later. The names used are those expected by the OAuth Common stack (see usage of `AuditTxmaStackName` in the [OAuth Common template](https://github.com/govuk-one-login/ipv-cri-oauth-common/blob/e10d29ca631e546ab47143a2e3148be284e8c55a/infrastructure/template.yaml#L21)).

### Why did it change
<!-- Describe the reason these changes were made - the "why" -->
<!-- Include all information the reviewer needs for context -->

We want to deploy the OAuth Common stack so that we can reuse lots of OAuth code rather than re-inventing the wheel. This is a pre-requisite to deploying the OAuth Common stack, which requires the name of the "audit stack" as input. Our "audit stack", i.e. the one that creates the queue to which we send SIS' audit messages, is the main SIS template. 