### PR TITLE
BAU: Fix bucket name in assets integration

### DIFF
--- a/openAPI/public-api.yaml
+++ b/openAPI/public-api.yaml
@@ -132,7 +132,7 @@ paths:
           Fn::GetAtt: AssetsResourceS3Role.Arn
         httpMethod: GET
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:s3:path/govuk-frontend-assets-${Environment}-${AWS::StackName}/{item}
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:s3:path/sis-govuk-frontend-assets-${Environment}-${AWS::StackName}/{item}
         responses:
           default:
             statusCode: "200"


### PR DESCRIPTION
## What

Add the `sis-` prefix to the bucket name for assets.

## Why

Assets are failing to fetch in the SIS environments.
