### PR TITLE
BAU: Use bucket reference in OpenAPI spec

### DIFF
--- a/openAPI/public-api.yaml
+++ b/openAPI/public-api.yaml
@@ -148,7 +148,7 @@ paths:
           Fn::GetAtt: AssetsResourceS3Role.Arn
         httpMethod: GET
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:s3:path/sis-govuk-frontend-assets-${Environment}-${AWS::StackName}/{item}
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:s3:path/${GovUKAssetsBucket}/{item}
         responses:
           default:
             statusCode: "200"


### PR DESCRIPTION
## What

Replace the bucket name concatenation with a simple reference to `GovUKAssetsBucket` in the `public-api.yaml` OpenAPI spec. 

## Why

This allows renaming of the bucket in one place only, if required, and prevents duplication and error (such as that fixed, yesterday, in #351.
