### PR TITLE
SPT-1950: updates workflows for OAuth stack

### DIFF
--- a/.github/aws-oidc-provider/gha-aws-oidc-provider-template.yaml
+++ b/.github/aws-oidc-provider/gha-aws-oidc-provider-template.yaml
@@ -357,6 +357,13 @@ Resources:
                   - application-autoscaling:DescribeScalingActivities
                   - application-autoscaling:DeleteScalingPolicy
 
+              - Effect: Allow
+                Resource: "arn:aws:serverlessrepo:eu-west-2:667736788427:applications/di-ipv-cri-oauth-common"
+                Action:
+                  - serverlessrepo:CreateCloudFormationTemplate
+                  - serverlessrepo:GetCloudFormationTemplate
+                  - serverlessrepo:GetApplication
+
   GithubOidc:
     Type: AWS::IAM::OIDCProvider
     Condition: CreateOIDCProvider

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,15 +8,27 @@ on:
         default: built-code
         required: false
         type: string
+      oauth-artifact-name:
+        description: Build artifact to download and publish
+        default: built-oauth-code
+        required: false
+        type: string
       aws-region:
         description: AWS Region to deploy
         default: eu-west-2
         required: false
         type: string
+    secrets:
+      aws-role-arn:
+        required: true
+        description: >
+          The Amazon Resource Name (ARN) of the role to assume. Use the provided credentials to assume an IAM role and
+          configure the Actions environment with the assumed role credentials rather than with the provided credentials.
 
 permissions:
   contents: read
   packages: read
+  id-token: write
 
 jobs:
   build:
@@ -41,6 +53,28 @@ jobs:
       - name: Install Dependencies
         run: npm ci --ignore-scripts
 
+      - name: Assume AWS Role
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
+        with:
+          role-to-assume: ${{ secrets.aws-role-arn }}
+          aws-region: ${{ inputs.aws-region }}
+
+      - name: Build OAuth SAM application
+        uses: govuk-one-login/github-actions/sam/build-application@1ef1d955b2fd248b51fc803f6b64ccac9f04cd84
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          enable-beta-features: true
+          template: "infrastructure/oauth-internal/template.yaml"
+          aws-region: ${{ inputs.aws-region }}
+          upload-artifact: true
+          artifact-name: ${{ inputs.oauth-artifact-name }}
+          sam-version: 1.155.2
+          additional-artifact-paths: |
+            openAPI/
+            .aws-sam/build/oauth-internal/
+            .aws-sam/cache/
+
       - name: Build SAM application
         uses: govuk-one-login/github-actions/sam/build-application@1ef1d955b2fd248b51fc803f6b64ccac9f04cd84
         env:
@@ -55,5 +89,5 @@ jobs:
           additional-artifact-paths: |
             openAPI/
             lambda-layers/
-            .aws-sam/build/
+            .aws-sam/build/identity-reuse-service/
             .aws-sam/cache/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,7 @@ jobs:
   build:
     name: Build Application
     runs-on: ubuntu-latest
+    environment: development
     env:
       AWS_REGION: ${{ inputs.aws-region }}
       SAM_CLI_TELEMETRY: "0"

--- a/.github/workflows/delete-deployment.yaml
+++ b/.github/workflows/delete-deployment.yaml
@@ -45,21 +45,22 @@ jobs:
           branch-name: preview-pr-${{ github.event.pull_request.number }}
           length-limit: ${{ env.STACK_NAME_LENGTH }}
 
-      - name: Get OAuth stack name
-        id: get-oauth-stack-name
-        if: ${{ github.event_name != 'schedule' }}
-        uses: govuk-one-login/github-actions/beautify-branch-name@f5362528578198e7851e96e0594f593beff0162e
-        with:
-          usage: Stack name
-          branch-name: preview-pr-${{ github.event.pull_request.number }}-oauth
-          length-limit: ${{ env.STACK_NAME_LENGTH }}
+#       N.B Uncomment this once the OAuth stack can be deployed
+#      - name: Get OAuth stack name
+#        id: get-oauth-stack-name
+#        if: ${{ github.event_name != 'schedule' }}
+#        uses: govuk-one-login/github-actions/beautify-branch-name@f5362528578198e7851e96e0594f593beff0162e
+#        with:
+#          usage: Stack name
+#          branch-name: preview-pr-${{ github.event.pull_request.number }}-oauth
+#          length-limit: ${{ env.STACK_NAME_LENGTH }}
 
       - name: Check stack exists
         if: ${{ github.event_name != 'schedule' }}
         id: check-stack-exists
         uses: govuk-one-login/github-actions/sam/check-stacks-exist@f5362528578198e7851e96e0594f593beff0162e
         with:
-          stack-names: ${{ steps.get-stack-name.outputs.pretty-branch-name }} ${{ steps.get-oauth-stack-name.outputs.pretty-branch-name }}
+          stack-names: ${{ steps.get-stack-name.outputs.pretty-branch-name }}
           set-env-var: STACKS_TO_DELETE
           verbose: true
 

--- a/.github/workflows/delete-deployment.yaml
+++ b/.github/workflows/delete-deployment.yaml
@@ -36,7 +36,7 @@ jobs:
           role-to-assume: ${{ secrets.GHA_AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Get stack name
+      - name: Get main stack name
         id: get-stack-name
         if: ${{ github.event_name != 'schedule' }}
         uses: govuk-one-login/github-actions/beautify-branch-name@f5362528578198e7851e96e0594f593beff0162e
@@ -45,12 +45,21 @@ jobs:
           branch-name: preview-pr-${{ github.event.pull_request.number }}
           length-limit: ${{ env.STACK_NAME_LENGTH }}
 
+      - name: Get OAuth stack name
+        id: get-oauth-stack-name
+        if: ${{ github.event_name != 'schedule' }}
+        uses: govuk-one-login/github-actions/beautify-branch-name@f5362528578198e7851e96e0594f593beff0162e
+        with:
+          usage: Stack name
+          branch-name: preview-pr-${{ github.event.pull_request.number }}-oauth
+          length-limit: ${{ env.STACK_NAME_LENGTH }}
+
       - name: Check stack exists
         if: ${{ github.event_name != 'schedule' }}
         id: check-stack-exists
         uses: govuk-one-login/github-actions/sam/check-stacks-exist@f5362528578198e7851e96e0594f593beff0162e
         with:
-          stack-names: ${{ steps.get-stack-name.outputs.pretty-branch-name }}
+          stack-names: ${{ steps.get-stack-name.outputs.pretty-branch-name }} ${{ steps.get-oauth-stack-name.outputs.pretty-branch-name }}
           set-env-var: STACKS_TO_DELETE
           verbose: true
 

--- a/.github/workflows/deploy-to-aws.yml
+++ b/.github/workflows/deploy-to-aws.yml
@@ -124,18 +124,19 @@ jobs:
           stack-names: ${{ env.STACK_NAME }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Deploy OAuth Stack
-        timeout-minutes: 15
-        run: |
-          echo "$OAUTH_STACK_NAME"
-          sam deploy \
-          --stack-name "$OAUTH_STACK_NAME"
-          --region "$AWS_REGION"  \
-          --no-confirm-changeset \
-          --no-fail-on-empty-changeset \
-          --capabilities CAPABILITY_NAMED_IAM \
-          --tags DeploymentSource="GitHub Actions" StackType=Preview \
-          --parameter-overrides Environment="dev" VpcStackName=vpc
+#      N.B. Comment out until we've solved the circular dependency
+#      - name: Deploy OAuth Stack
+#        timeout-minutes: 15
+#        run: |
+#          echo "$OAUTH_STACK_NAME"
+#          sam deploy \
+#          --stack-name "$OAUTH_STACK_NAME"
+#          --region "$AWS_REGION"  \
+#          --no-confirm-changeset \
+#          --no-fail-on-empty-changeset \
+#          --capabilities CAPABILITY_NAMED_IAM,CAPABILITY_AUTO_EXPAND \
+#          --tags DeploymentSource="GitHub Actions" StackType=Preview \
+#          --parameter-overrides Environment="dev" SisStackName=preview-main
 
       - name: Deploy SAM Application
         timeout-minutes: 15
@@ -153,7 +154,7 @@ jobs:
             --no-fail-on-empty-changeset \
             --capabilities CAPABILITY_NAMED_IAM \
             --tags DeploymentSource="GitHub Actions" StackType=Preview \
-            --parameter-overrides Environment="dev" VpcStackName=vpc
+            --parameter-overrides Environment="dev"
 
       - name: Report deployment
         run: echo "Deployed stack \`$STACK_NAME\`, \`$OAUTH_STACK_NAME`\" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-to-aws.yml
+++ b/.github/workflows/deploy-to-aws.yml
@@ -8,6 +8,12 @@ on:
           The name of the stack to deploy. If this is not provided the stack name is generated from the branch name.
         required: false
         type: string
+      oauth-stack-name:
+        description: >
+          The name of the OAuth Common stack to deploy. If this is not provided the stack name is generated from the branch name.
+        default: preview-pr-${{ github.event.pull_request.number }}-oauth"
+        required: false
+        type: string
       environment-name:
         description: >
           The name of the environment. If this is not provided it's taken from the branch name.
@@ -27,6 +33,9 @@ on:
       stack-name:
         description: The name of the deployed stack
         value: ${{ jobs.deploy.outputs.stack-name }}
+      oauth-stack-name:
+        description: The name of the deployed OAuth stack
+        value: ${{ jobs.deploy-oauth.outputs.stack-name }} #IS THIS NEEDED?
     secrets:
       aws-role-arn:
         required: true
@@ -101,10 +110,12 @@ jobs:
         env:
           STACK_NAME: ${{ inputs.stack-name }}
           ENVIRONMENT_NAME: ${{ inputs.environment-name }}
+          OAUTH_STACK_NAME: ${{ inputs.oauth-stack-name }}
         run: |
           echo "ENVIRONMENT_NAME=${ENVIRONMENT_NAME}" >> "$GITHUB_ENV"
           echo "STACK_NAME=${STACK_NAME}" >> "$GITHUB_ENV"
           echo "S3_PREFIX=${STACK_NAME}" >> "$GITHUB_ENV"
+          echo "OAUTH_STACK_NAME=${OAUTH_STACK_NAME}" >> "$GITHUB_ENV"
 
       - name: Delete failed stack
         uses: govuk-one-login/github-actions/sam/delete-stacks@0eb1972f8c0d539b3ff4c24d78b3dba917343e7c
@@ -112,6 +123,20 @@ jobs:
           only-if-failed: true
           stack-names: ${{ env.STACK_NAME }}
           aws-region: ${{ env.AWS_REGION }}
+
+# WHAT SHOULD THIS STACK NAME BE? WILL EACH DEPLOY USE THE SAME ONE?
+      - name: Deploy OAuth Stack
+        timeout-minutes: 15
+        run: |
+          echo "$OAUTH_STACK_NAME"
+          sam deploy \
+          --stack-name "$OAUTH_STACK_NAME"
+          --region "$AWS_REGION"  \
+          --no-confirm-changeset \
+          --no-fail-on-empty-changeset \
+          --capabilities CAPABILITY_NAMED_IAM \
+          --tags DeploymentSource="GitHub Actions" StackType=Preview \
+          --parameter-overrides Environment="dev" VpcStackName=vpc
 
       - name: Deploy SAM Application
         timeout-minutes: 15
@@ -132,8 +157,8 @@ jobs:
             --parameter-overrides Environment="dev" VpcStackName=vpc
 
       - name: Report deployment
-        run: echo "Deployed stack \`$STACK_NAME\`" >> "$GITHUB_STEP_SUMMARY"
+        run: echo "Deployed stack \`$STACK_NAME\`, \`$OAUTH_STACK_NAME`\" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Output Stack Name
         id: output-stack-name
-        run: echo "STACK_NAME=$STACK_NAME" >> "$GITHUB_OUTPUT"
+        run: echo "STACK_NAME=$STACK_NAME, OAUTH_STACK_NAME=$OAUTH_STACK_NAME" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy-to-aws.yml
+++ b/.github/workflows/deploy-to-aws.yml
@@ -157,8 +157,9 @@ jobs:
             --parameter-overrides Environment="dev"
 
       - name: Report deployment
-        run: echo "Deployed stack \`$STACK_NAME\`, \`$OAUTH_STACK_NAME`\" >> "$GITHUB_STEP_SUMMARY"
+        run: echo "Deployed stack \`$STACK_NAME\` >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Output Stack Name
-        id: output-stack-name
-        run: echo "STACK_NAME=$STACK_NAME, OAUTH_STACK_NAME=$OAUTH_STACK_NAME" >> "$GITHUB_OUTPUT"
+#       N.B Uncomment if this output is needed when the above deployment is fixed
+#      - name: Output Stack Name
+#        id: output-stack-name
+#        run: echo "STACK_NAME=$STACK_NAME, OAUTH_STACK_NAME=$OAUTH_STACK_NAME" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy-to-aws.yml
+++ b/.github/workflows/deploy-to-aws.yml
@@ -35,7 +35,7 @@ on:
         value: ${{ jobs.deploy.outputs.stack-name }}
       oauth-stack-name:
         description: The name of the deployed OAuth stack
-        value: ${{ jobs.deploy-oauth.outputs.stack-name }} #IS THIS NEEDED?
+        value: ${{ jobs.deploy-oauth.outputs.stack-name }}
     secrets:
       aws-role-arn:
         required: true

--- a/.github/workflows/deploy-to-aws.yml
+++ b/.github/workflows/deploy-to-aws.yml
@@ -124,7 +124,6 @@ jobs:
           stack-names: ${{ env.STACK_NAME }}
           aws-region: ${{ env.AWS_REGION }}
 
-# WHAT SHOULD THIS STACK NAME BE? WILL EACH DEPLOY USE THE SAME ONE?
       - name: Deploy OAuth Stack
         timeout-minutes: 15
         run: |

--- a/.github/workflows/deploy-to-aws.yml
+++ b/.github/workflows/deploy-to-aws.yml
@@ -157,9 +157,8 @@ jobs:
             --parameter-overrides Environment="dev"
 
       - name: Report deployment
-        run: echo "Deployed stack \`$STACK_NAME\` >> "$GITHUB_STEP_SUMMARY"
+        run: echo "Deployed stack \`$STACK_NAME\`" >> "$GITHUB_STEP_SUMMARY"
 
-#       N.B Uncomment if this output is needed when the above deployment is fixed
-#      - name: Output Stack Name
-#        id: output-stack-name
-#        run: echo "STACK_NAME=$STACK_NAME, OAUTH_STACK_NAME=$OAUTH_STACK_NAME" >> "$GITHUB_OUTPUT"
+      - name: Output Stack Name
+        id: output-stack-name
+        run: echo "STACK_NAME=$STACK_NAME" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -60,6 +60,9 @@ jobs:
     permissions:
       contents: read
       packages: read
+      id-token: write
+    secrets:
+      aws-role-arn: ${{ secrets.GHA_AWS_ROLE_ARN }}
 
   run-tests:
     uses: ./.github/workflows/test.yml

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -117,7 +117,28 @@ jobs:
       aws-role-arn: ${{ secrets.GHA_AWS_ROLE_ARN }}
       ecr-repository: ${{ secrets.TEST_IMAGE_ECR_REPOSITORY }}
 
-  publish:
+
+  publish-oauth:
+    uses: ./.github/workflows/publish.yml
+    needs:
+      - publish-test-image
+      - acceptance-test
+    if: |
+      always() &&
+      (needs.publish-test-image.result == 'success' || needs.publish-test-image.result == 'skipped') &&
+      (needs.acceptance-test.result == 'success')
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      artifact-name: built-oauth-code
+      aws-region: eu-west-2
+    secrets:
+      aws-role-arn: ${{ secrets.GHA_OAUTH_AWS_ROLE_ARN }}
+      sam-s3-bucket: ${{ secrets.GHA_OAUTH_SAM_DEPLOYMENT_BUCKET }}
+      signing-profile-name: ${{ secrets.SIGNING_PROFILE_NAME }}
+
+  publish-sis:
     uses: ./.github/workflows/publish.yml
     needs:
       - publish-test-image

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -69,6 +69,6 @@ jobs:
       id-token: write
       contents: read
     with:
-      stack-name: ${{ needs.preview.outputs.stack-name }} # Will OAUTH stack be needed here?
+      stack-name: ${{ needs.preview.outputs.stack-name }}
     secrets:
       aws-role-arn: ${{ secrets.GHA_AWS_ROLE_ARN }}

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -18,6 +18,7 @@ jobs:
       aws-region: eu-west-2
     permissions:
       contents: read
+      id-token: write
       packages: read
     secrets:
       aws-role-arn: ${{ secrets.GHA_AWS_ROLE_ARN }}

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -19,6 +19,8 @@ jobs:
     permissions:
       contents: read
       packages: read
+    secrets:
+      aws-role-arn: ${{ secrets.GHA_AWS_ROLE_ARN }}
 
   run-tests:
     if: ${{ !github.event.pull_request.draft }}

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -66,6 +66,6 @@ jobs:
       id-token: write
       contents: read
     with:
-      stack-name: ${{ needs.preview.outputs.stack-name }}
+      stack-name: ${{ needs.preview.outputs.stack-name }} # Will OAUTH stack be needed here?
     secrets:
       aws-role-arn: ${{ secrets.GHA_AWS_ROLE_ARN }}

--- a/infrastructure/oauth-internal/template.yaml
+++ b/infrastructure/oauth-internal/template.yaml
@@ -106,11 +106,6 @@ Parameters:
     Type: String
     Default: vpc
 
-  VpcStackName:
-    Description: The name of the stack containing VPC infrastructure
-    Type: String
-    Default: vpc
-
 Mappings:
   EnvironmentMap:
     "local":

--- a/infrastructure/oauth-internal/template.yaml
+++ b/infrastructure/oauth-internal/template.yaml
@@ -74,6 +74,7 @@ Parameters:
   SisStackName:
     Description: The name of the main SIS stack containing audit queue infrastructure
     Type: String
+    Default: sis-main
 
   OAuthClientId:
     Description: "The client ID used by the main OAuth client"


### PR DESCRIPTION
## What

<!-- Describe the changes in detail - the "what"-->
<!-- Include all information the reviewer needs for context -->

This updates `delete-deployment`, `deploy-to-aws` and the `pre-merge-checks` workflows to account for the OAuth stack. 

An extra step to get the OAuth stack name and to deploy it has been added. 

For deleting the stacks, these are now passed in as 1 string when checking the stacks exist (which should work with the [space between the stack names](https://github.com/govuk-one-login/github-actions/blob/main/sam/check-stacks-exist/action.yml)). 

> [!NOTE]
> We are deliberately not deploying in the pre-merge steps, we will enable this after we solved the 

## Why

<!-- Describe the reason these changes were made - the "why" -->
<!-- Include all information the reviewer needs for context -->

The new OAuth stack needs to be deployed and deleted. 

## Related PRs

<!-- Include links to any PRs, in this repo or others, related to this change, for example a related configuration change (delete this section if not applicable) -->
Adding the pipeline: https://github.com/govuk-one-login/ipv-trust-and-reuse-common-infra/pull/222 