### PR TITLE
SPT-1973: Create /oauth/callback endpoint

### DIFF
--- a/infrastructure/identity-reuse-service/template.yaml
+++ b/infrastructure/identity-reuse-service/template.yaml
@@ -1435,6 +1435,129 @@ Resources:
         - Key: Name
           Value: !Sub "/aws/lambda/${UnrecoverableErrorLambda}"
 
+  GetCallbackHandler:
+    Type: AWS::Serverless::Function
+    Condition: IsNotProduction
+    Properties:
+      FunctionName: !Sub "${AWS::StackName}-GetCallbackHandler"
+      Handler: get-callback-handler.handler
+      Role: !GetAtt GetCallbackHandlerRole.Arn
+      Environment:
+        Variables:
+          NODE_OPTIONS: "--enable-source-maps"
+          DOMAIN_NAME: !Ref ReuseIdentityCustomDomain
+          OAUTH_INTERNAL_API:
+            Fn::Sub:
+              - "${OauthInternalStackId}"
+              - OauthInternalStackId:
+                  Fn::ImportValue: !Sub "${OauthInternalStackName}-PrivateApi"
+      Layers:
+        - !Ref GovUKFrontEndLayer
+        - !If
+          - DynaTraceEnabled
+          - !Ref DynatraceNodeLayerArn
+          - !Ref AWS::NoValue
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        UseNpmCi: True
+        Minify: true
+        Target: es2022
+        Sourcemap: true
+        SourcesContent: false
+        EntryPoints:
+          - src/handlers/get-callback-handler/get-callback-handler.ts
+        Format: esm
+        Platform: node
+        OutExtension:
+          - .js=.mjs
+        Banner:
+          - js=import { createRequire } from 'module'; const require = createRequire(import.meta.url);
+
+  GetCallbackHandlerRole:
+    # checkov:skip=CKV_AWS_111: Ensure IAM policies does not allow write access without constraints
+    Type: AWS::IAM::Role
+    Condition: IsNotProduction
+    Properties:
+      PermissionsBoundary: !If
+        - UsePermissionsBoundary
+        - !Ref PermissionsBoundary
+        - !Ref AWS::NoValue
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action:
+              - "sts:AssumeRole"
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+
+  GetCallbackHandlerRestApiRole:
+    Type: AWS::IAM::Role
+    Condition: IsNotProduction
+    Properties:
+      RoleName: !Sub "${AWS::StackName}-GetCallbackHandlerRestApiRole"
+      Description: !Sub "Roles for the GetCallbackHandler"
+      PermissionsBoundary: !If [ UsePermissionsBoundary, !Ref PermissionsBoundary, !Ref AWS::NoValue ]
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: apigateway.amazonaws.com
+            Action:
+              - "sts:AssumeRole"
+      Tags:
+        - Key: Product
+          Value: !Ref ProductTagValue
+        - Key: System
+          Value: !Ref SystemTagValue
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: Owner
+          Value: !Ref OwnerTagValue
+        - Key: Source
+          Value: !Ref SourceTagValue
+
+  GetCallbackHandlerRestApiPolicy:
+    Type: AWS::IAM::Policy
+    Condition: IsNotProduction
+    Properties:
+      PolicyName: !Sub "${AWS::StackName}-GetCallbackHandlerRestApiPolicy"
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: "Allow"
+            Action:
+              - "lambda:InvokeFunction"
+            Resource:
+              - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${AWS::StackName}-GetCallbackHandler:*"
+      Roles:
+        - !Ref GetCallbackHandlerRestApiRole
+
+  GetCallbackHandlerLogGroup:
+    Type: AWS::Logs::LogGroup
+    Condition: IsNotProduction
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${GetCallbackHandler}"
+      RetentionInDays: 30
+      KmsKeyId: !GetAtt CloudWatchEncryptionKey.Arn
+      Tags:
+        - Key: Product
+          Value: !Ref ProductTagValue
+        - Key: System
+          Value: !Ref SystemTagValue
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: Owner
+          Value: !Ref OwnerTagValue
+        - Key: Source
+          Value: !Ref SourceTagValue
+        - Key: Name
+          Value: !Sub "/aws/lambda/${GetCallbackHandler}"
+
   ################################
   # PRIVATE API API GATEWAY       #
   ################################

--- a/openAPI/public-api.yaml
+++ b/openAPI/public-api.yaml
@@ -160,6 +160,18 @@ paths:
         requestParameters:
           integration.request.path.item: method.request.path.item
         type: aws
+  /oauth2/callback:
+    get:
+      responses:
+        "302":
+          $ref: "#/components/responses/AuthorizationRedirect"
+      x-amazon-apigateway-integration:
+        httpMethod: POST
+        uri:
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${GetCallbackHandler.Arn}:live/invocations
+        credentials:
+          Fn::GetAtt: GetCallbackHandlerRestApiRole.Arn
+        type: aws_proxy
 
 components:
   parameters:

--- a/package-lock.json
+++ b/package-lock.json
@@ -5145,16 +5145,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/hosted-git-info/node_modules/lru-cache": {
-      "version": "11.2.4",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
-      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -5936,6 +5926,16 @@
       "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/luxon": {
       "version": "3.7.2",

--- a/src/commons/cookie-utilities.ts
+++ b/src/commons/cookie-utilities.ts
@@ -1,0 +1,33 @@
+import { APIGatewayProxyEvent } from "aws-lambda";
+import logger from "./logger";
+
+export const getCookieValues = (event: Partial<APIGatewayProxyEvent>): Map<string, string> | undefined => {
+  const lowercaseHeaders = Object.fromEntries(
+    Object.entries(event.headers!).map(([key, value]) => [key.toLowerCase(), value])
+  );
+
+  const cookieHeader = lowercaseHeaders["cookie"];
+
+  if (!cookieHeader) {
+    return undefined;
+  }
+
+  const cookies = cookieHeader.split(";");
+
+  const cookieValues = new Map<string, string>();
+  for (const element of cookies) {
+    const cookie = element.trim();
+    const separatorIndex = cookie.indexOf("=");
+    const cookieName = cookie.slice(0, separatorIndex);
+    const cookieValue = cookie.slice(separatorIndex + 1);
+    try {
+      const decodedCookieValue = decodeURIComponent(cookieValue!);
+      cookieValues.set(cookieName, decodedCookieValue);
+    } catch (error) {
+      logger.error(`Error decoding cookie: ${error}`);
+      return undefined;
+    }
+  }
+
+  return cookieValues;
+};

--- a/src/commons/tests/cookie-utilities.test.ts
+++ b/src/commons/tests/cookie-utilities.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vitest } from "vitest";
+import { APIGatewayEventRequestContextWithAuthorizer, APIGatewayProxyEvent } from "aws-lambda";
+import { getCookieValues } from "../cookie-utilities";
+
+describe("cookie-utilities", () => {
+  it("should return all cookie values", async () => {
+    const event = createMockAPIGatewayProxyEvent({}, "");
+    const mapOfCookies = getCookieValues(event);
+    expect(mapOfCookies).length(2);
+    expect(mapOfCookies!.get("test_cookie_one")).toBe("abc123");
+    expect(mapOfCookies!.get("test_cookie_two")).toBe("xyz246");
+  });
+
+  it("should return the specific value for the provided cookie name", async () => {
+    const event = createMockAPIGatewayProxyEvent({}, "");
+    const mapOfCookies = getCookieValues(event);
+    expect(mapOfCookies).length(2);
+    expect(mapOfCookies!.get("test_cookie_one")).toBe("abc123");
+  });
+
+  it("should return undefined when an error is thrown", async () => {
+    const decodeSpy = vitest.spyOn(globalThis, "decodeURIComponent").mockImplementation(() => {
+      throw new URIError("URI malformed");
+    });
+    const event = createMockAPIGatewayProxyEvent({}, "");
+    const mapOfCookies = getCookieValues(event);
+    expect(decodeSpy).toHaveBeenCalled();
+    expect(mapOfCookies).toBe(undefined);
+  });
+});
+
+const createMockAPIGatewayProxyEvent = (event: Partial<APIGatewayProxyEvent>, body: string): APIGatewayProxyEvent => ({
+  body: body,
+  headers: { Cookie: "test_cookie_one=abc123;test_cookie_two=xyz246" },
+  multiValueHeaders: {},
+  httpMethod: "POST",
+  isBase64Encoded: false,
+  path: "/",
+  // eslint-disable-next-line unicorn/no-null -- Required to create valid APIGatewayProxyEvent
+  pathParameters: null,
+  queryStringParameters: { redirect_uri: "https://api.example.com", state: "test-state", client_id: "test-client-id" },
+  // eslint-disable-next-line unicorn/no-null -- Required to create valid APIGatewayProxyEvent
+  multiValueQueryStringParameters: null,
+  // eslint-disable-next-line unicorn/no-null -- Required to create valid APIGatewayProxyEvent
+  stageVariables: null,
+  requestContext: {} as APIGatewayEventRequestContextWithAuthorizer<never>,
+  resource: "/",
+  ...event,
+});

--- a/src/handlers/get-callback-handler/get-callback-handler.ts
+++ b/src/handlers/get-callback-handler/get-callback-handler.ts
@@ -1,0 +1,86 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import logger from "../../commons/logger";
+import { URL } from "node:url";
+import { getCookieValues } from "../../commons/cookie-utilities";
+import { AuthorizationSuccessResponse, isValidSuccessResponse } from "./get-callback-response";
+import { isValidQueryParameters } from "./get-callback-request";
+
+export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+  const queryParameters = event.queryStringParameters || {};
+
+  const domainName = process.env.DOMAIN_NAME || "";
+
+  if (!isValidQueryParameters(queryParameters)) {
+    logger.error("Missing mandatory query string parameters to the GetCallbackHandler");
+    return await redirectToErrorPage(domainName);
+  }
+
+  const sessionId = getCookieValues(event)?.get("identity_reuse_service_session");
+
+  if (!sessionId) {
+    return await redirectToErrorPage(domainName);
+  }
+
+  const oauthInternalApiUrl = process.env.OAUTH_INTERNAL_API;
+  const url = new URL(`${oauthInternalApiUrl}/api/authorization`);
+
+  url.searchParams.append("client_id", queryParameters.client_id);
+  url.searchParams.append("redirect_uri", queryParameters.redirect_uri);
+  url.searchParams.append("response_type", "code");
+
+  try {
+    const responseFromAuthorizeEndpoint = await fetch(url, {
+      method: "GET",
+      headers: {
+        "session-id": sessionId,
+      },
+    });
+
+    if (responseFromAuthorizeEndpoint.status === 200) {
+      return await redirectToClient(responseFromAuthorizeEndpoint, domainName);
+    } else if (responseFromAuthorizeEndpoint.status === 403) {
+      return await redirectToClientWithError(queryParameters.redirect_uri, queryParameters.state);
+    } else {
+      logger.error(`${responseFromAuthorizeEndpoint.status} response code returned from the authorization endpoint`);
+      return await redirectToErrorPage(domainName);
+    }
+  } catch (error) {
+    logger.error(`Error in OAuth Callback handler event: ${error}`);
+    return await redirectToErrorPage(domainName);
+  }
+};
+
+const redirectToClient = async (authorizationResponse: Response, domainName: string) => {
+  if (!isValidSuccessResponse(await authorizationResponse.json())) {
+    logger.error("Invalid response properties received from authorization endpoint");
+    return await redirectToErrorPage(domainName);
+  }
+
+  const authorizationData = (await authorizationResponse.json()) as AuthorizationSuccessResponse;
+  const orchestrationRedirectUrl = new URL(decodeURIComponent(authorizationData.redirectionURI));
+  orchestrationRedirectUrl.searchParams.append("code", authorizationData.authorizationCode.value);
+  orchestrationRedirectUrl.searchParams.append("state", authorizationData.state.value);
+  return redirect(`${orchestrationRedirectUrl}`);
+};
+
+const redirectToClientWithError = async (redirectUri: string, state: string) => {
+  const orchestrationRedirectUrl = new URL(redirectUri);
+  orchestrationRedirectUrl.searchParams.append("error", "access_denied");
+  // To be replaced with the state returned by the /authorization endpoint once it's added to the oauth-common response
+  orchestrationRedirectUrl.searchParams.append("state", state);
+  return redirect(`${orchestrationRedirectUrl}`);
+};
+
+const redirectToErrorPage = async (domainName: string) => {
+  return await redirect(`https://${domainName}/error/unrecoverable`);
+};
+
+const redirect = async (location: string) => {
+  return {
+    statusCode: 302,
+    headers: {
+      Location: location,
+    },
+    body: "",
+  };
+};

--- a/src/handlers/get-callback-handler/get-callback-request.ts
+++ b/src/handlers/get-callback-handler/get-callback-request.ts
@@ -1,0 +1,20 @@
+export interface AuthorizationQueryStringParameters {
+  redirect_uri: string;
+  state: string;
+  client_id: string;
+}
+
+export function isValidQueryParameters(object: unknown): object is AuthorizationQueryStringParameters {
+  if (!object || typeof object !== "object") return false;
+  return (
+    "redirect_uri" in object &&
+    typeof object.redirect_uri === "string" &&
+    object.redirect_uri.trim().length > 0 &&
+    "state" in object &&
+    typeof object.state === "string" &&
+    object.state.trim().length > 0 &&
+    "client_id" in object &&
+    typeof object.client_id === "string" &&
+    object.client_id.trim().length > 0
+  );
+}

--- a/src/handlers/get-callback-handler/get-callback-response.ts
+++ b/src/handlers/get-callback-handler/get-callback-response.ts
@@ -1,0 +1,33 @@
+export interface AuthorizationSuccessResponse {
+  redirectionURI: string;
+  authorizationCode: { value: string };
+  state: { value: string };
+}
+
+export function isValidSuccessResponse(object: unknown): object is AuthorizationSuccessResponse {
+  if (!object || typeof object !== "object") return false;
+  if (!(
+    "redirectionURI" in object &&
+    typeof object.redirectionURI === "string" &&
+    object.redirectionURI.trim().length > 0
+  )) {
+    return false;
+  }
+
+  if (!("authorizationCode" in object && object.authorizationCode && typeof object.authorizationCode === "object")) {
+    return false;
+  }
+
+  if (!("state" in object && object.state && typeof object.state === "object")) {
+    return false;
+  }
+
+  return (
+    "value" in object.authorizationCode &&
+    typeof object.authorizationCode.value === "string" &&
+    object.authorizationCode.value.trim().length > 0 &&
+    "value" in object.state &&
+    typeof object.state.value === "string" &&
+    object.state.value.trim().length > 0
+  );
+}

--- a/src/handlers/get-callback-handler/tests/get-callback-handler.test.ts
+++ b/src/handlers/get-callback-handler/tests/get-callback-handler.test.ts
@@ -1,0 +1,262 @@
+import { APIGatewayEventRequestContextWithAuthorizer, APIGatewayProxyEvent } from "aws-lambda";
+import { expect, it, vitest } from "vitest";
+import { handler } from "../get-callback-handler";
+import { getCookieValues } from "../../../commons/cookie-utilities";
+
+process.env.DOMAIN_NAME = "test-domain";
+process.env.OAUTH_INTERNAL_API = "https://test.com";
+
+const { mockError } = vitest.hoisted(() => {
+  return {
+    mockError: vitest.fn(),
+  };
+});
+
+vitest.mock("@aws-lambda-powertools/logger", () => {
+  return {
+    Logger: class {
+      error = mockError;
+      constructor() {}
+    },
+  };
+});
+
+it("should return a 302 status code and redirect with an auth code and state on a successful request", async () => {
+  const event = createMockAPIGatewayProxyEvent({}, "");
+  const token = getCookieValues(event)!.get("identity_reuse_service_session");
+  expect(token).toBe("abc123");
+
+  globalThis.fetch = vitest.fn().mockResolvedValue({
+    status: 200,
+    json: vitest.fn().mockResolvedValue({
+      redirectionURI: "https://api.example.com",
+      authorizationCode: { value: "test-auth-code" },
+      state: { value: "test-state" },
+    }),
+  });
+
+  const response = await handler(event);
+  expect(response).toStrictEqual({
+    statusCode: 302,
+    body: "",
+    headers: {
+      Location: "https://api.example.com/?code=test-auth-code&state=test-state",
+    },
+  });
+});
+
+it("should return a 302 status code and redirect with an access_denied error and state when /api/authorization API call returns 403", async () => {
+  const event = createMockAPIGatewayProxyEvent({}, "");
+
+  globalThis.fetch = vitest.fn().mockResolvedValue({
+    status: 403,
+    json: vitest.fn().mockResolvedValue({
+      error: "access_denied",
+      state: "test-state",
+    }),
+  });
+
+  const response = await handler(event);
+  expect(response).toStrictEqual({
+    statusCode: 302,
+    body: "",
+    headers: {
+      Location: "https://api.example.com/?error=access_denied&state=test-state",
+    },
+  });
+});
+
+it("should return a 302 status code and redirect to the SIS error page when /api/authorization API call returns 400", async () => {
+  const event = createMockAPIGatewayProxyEvent({}, "");
+
+  globalThis.fetch = vitest.fn().mockResolvedValue({
+    status: 400,
+    json: vitest.fn().mockResolvedValue({
+      error: "access_denied",
+      state: "test-state",
+    }),
+  });
+
+  const response = await handler(event);
+  expect(response).toStrictEqual({
+    statusCode: 302,
+    body: "",
+    headers: {
+      Location: "https://test-domain/error/unrecoverable",
+    },
+  });
+});
+
+it("should return a 302 status code and redirect to error page when /api/authorization API call returns 500", async () => {
+  const event = createMockAPIGatewayProxyEvent({}, "");
+
+  globalThis.fetch = vitest.fn().mockResolvedValue({
+    status: 500,
+    json: vitest.fn().mockResolvedValue({
+      error: "access_denied",
+      state: "test-state",
+    }),
+  });
+
+  const response = await handler(event);
+  expect(response).toStrictEqual({
+    statusCode: 302,
+    body: "",
+    headers: {
+      Location: "https://test-domain/error/unrecoverable",
+    },
+  });
+});
+
+it("should return a 302 status code and redirect to error page when a call to the /api/authorization API fails", async () => {
+  const event = createMockAPIGatewayProxyEvent({}, "");
+
+  globalThis.fetch = vitest.fn().mockRejectedValue(new Error("TypeError: API call failed"));
+
+  const response = await handler(event);
+  expect(response).toStrictEqual({
+    statusCode: 302,
+    body: "",
+    headers: {
+      Location: "https://test-domain/error/unrecoverable",
+    },
+  });
+});
+
+it("should return a 302 status code and redirect to error page when the cookie is not set in the header", async () => {
+  const event = createMockAPIGatewayProxyEvent({}, "");
+  delete event.headers["Cookie"];
+
+  const token = getCookieValues(event)?.get("identity_reuse_service_session");
+  expect(token).toBe(undefined);
+  const response = await handler(event);
+  expect(response).toStrictEqual({
+    statusCode: 302,
+    body: "",
+    headers: {
+      Location: "https://test-domain/error/unrecoverable",
+    },
+  });
+});
+
+it("should log an error and redirect to the SIS error page if any of the required query string parameters are missing", async () => {
+  const event = createMockAPIGatewayProxyEvent({}, "");
+  delete event.queryStringParameters!["redirect_uri"];
+
+  globalThis.fetch = vitest.fn().mockResolvedValue({
+    status: 200,
+    json: vitest.fn().mockResolvedValue({
+      redirectionURI: "https://api.example.com",
+      authorizationCode: { value: "test-auth-code" },
+      state: { value: "test-state" },
+    }),
+  });
+
+  const response = await handler(event);
+  expect(response).toStrictEqual({
+    statusCode: 302,
+    body: "",
+    headers: {
+      Location: "https://test-domain/error/unrecoverable",
+    },
+  });
+
+  expect(mockError).toHaveBeenCalledWith(expect.stringContaining("Missing mandatory query string parameters"));
+});
+
+it("should log an error and redirect to the SIS error page if the authorization endpoint returns a missing redirection URI", async () => {
+  const event = createMockAPIGatewayProxyEvent({}, "");
+
+  globalThis.fetch = vitest.fn().mockResolvedValue({
+    status: 200,
+    json: vitest.fn().mockResolvedValue({
+      authorizationCode: { value: "test-auth-code" },
+      state: { value: "test-state" },
+    }),
+  });
+
+  const response = await handler(event);
+  expect(response).toStrictEqual({
+    statusCode: 302,
+    body: "",
+    headers: {
+      Location: "https://test-domain/error/unrecoverable",
+    },
+  });
+
+  expect(mockError).toHaveBeenCalled();
+  expect(mockError).toHaveBeenCalledWith(
+    expect.stringContaining("Invalid response properties received from authorization endpoint")
+  );
+});
+
+it("should log an error and redirect to the SIS error page if the authorization endpoint returns a missing auth code", async () => {
+  const event = createMockAPIGatewayProxyEvent({}, "");
+
+  globalThis.fetch = vitest.fn().mockResolvedValue({
+    status: 200,
+    json: vitest.fn().mockResolvedValue({
+      redirectionURI: "https://api.example.com",
+      state: { value: "test-state" },
+    }),
+  });
+
+  const response = await handler(event);
+  expect(response).toStrictEqual({
+    statusCode: 302,
+    body: "",
+    headers: {
+      Location: "https://test-domain/error/unrecoverable",
+    },
+  });
+
+  expect(mockError).toHaveBeenCalled();
+  expect(mockError).toHaveBeenCalledWith(
+    expect.stringContaining("Invalid response properties received from authorization endpoint")
+  );
+});
+
+it("should log an error and redirect to the SIS error page if the authorization endpoint returns a missing state", async () => {
+  const event = createMockAPIGatewayProxyEvent({}, "");
+
+  globalThis.fetch = vitest.fn().mockResolvedValue({
+    status: 200,
+    json: vitest.fn().mockResolvedValue({
+      redirectionURI: "https://api.example.com",
+      authorizationCode: { value: "test-auth-code" },
+    }),
+  });
+
+  const response = await handler(event);
+  expect(response).toStrictEqual({
+    statusCode: 302,
+    body: "",
+    headers: {
+      Location: "https://test-domain/error/unrecoverable",
+    },
+  });
+
+  expect(mockError).toHaveBeenCalled();
+  expect(mockError).toHaveBeenCalledWith(
+    expect.stringContaining("Invalid response properties received from authorization endpoint")
+  );
+});
+
+const createMockAPIGatewayProxyEvent = (event: Partial<APIGatewayProxyEvent>, body: string): APIGatewayProxyEvent => ({
+  body: body,
+  headers: { Cookie: "identity_reuse_service_session=abc123" },
+  multiValueHeaders: {},
+  httpMethod: "POST",
+  isBase64Encoded: false,
+  path: "/",
+  // eslint-disable-next-line unicorn/no-null -- Required to create valid APIGatewayProxyEvent
+  pathParameters: null,
+  queryStringParameters: { redirect_uri: "https://api.example.com", state: "test-state", client_id: "test-client-id" },
+  // eslint-disable-next-line unicorn/no-null -- Required to create valid APIGatewayProxyEvent
+  multiValueQueryStringParameters: null,
+  // eslint-disable-next-line unicorn/no-null -- Required to create valid APIGatewayProxyEvent
+  stageVariables: null,
+  requestContext: {} as APIGatewayEventRequestContextWithAuthorizer<never>,
+  resource: "/",
+  ...event,
+});


### PR DESCRIPTION
## What
#### [SPT-1973](https://govukverify.atlassian.net/browse/SPT-1973)
- Created a new `/oauth/callback` endpoint that calls the `/api/authorization` endpoint to retrieve the authorization code and redirect users on a successful request
- Included error handling logic for failed API requests and missing auth codes

**Note**: This change uses a test Session ID, which will be replaced with the actual cookie value once [SPT-1937](https://govukverify.atlassian.net/browse/SPT-1937) changes are applied

## Why
This endpoint will support the auth code exchange with Orchestration, and a user will be redirected to this endpoint after the auth code has been stored in the session table.

## Testing
Tested successful and unsuccessful scenarios in dev. Used the Orchestration stub to generate the JAR and manually called the `/api/session` endpoint with the JAR to create and store a Session ID in Dynamo. Using this Session ID value, I tested the `/oauth/callback` endpoint, which is returning the expected responses in each scenario.

[SPT-1973]: https://govukverify.atlassian.net/browse/SPT-1973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SPT-1937]: https://govukverify.atlassian.net/browse/SPT-1937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ