### PR TITLE
SPT-1937: Validate JAR on `/authorize`

### DIFF
--- a/.github/workflows/deploy-to-aws.yml
+++ b/.github/workflows/deploy-to-aws.yml
@@ -124,19 +124,19 @@ jobs:
           stack-names: ${{ env.STACK_NAME }}
           aws-region: ${{ env.AWS_REGION }}
 
-#      N.B. Comment out until we've solved the circular dependency
-#      - name: Deploy OAuth Stack
-#        timeout-minutes: 15
-#        run: |
-#          echo "$OAUTH_STACK_NAME"
-#          sam deploy \
-#          --stack-name "$OAUTH_STACK_NAME"
-#          --region "$AWS_REGION"  \
-#          --no-confirm-changeset \
-#          --no-fail-on-empty-changeset \
-#          --capabilities CAPABILITY_NAMED_IAM,CAPABILITY_AUTO_EXPAND \
-#          --tags DeploymentSource="GitHub Actions" StackType=Preview \
-#          --parameter-overrides Environment="dev" SisStackName=preview-main
+      #      N.B. Comment out until we've solved the circular dependency
+      #      - name: Deploy OAuth Stack
+      #        timeout-minutes: 15
+      #        run: |
+      #          echo "$OAUTH_STACK_NAME"
+      #          sam deploy \
+      #          --stack-name "$OAUTH_STACK_NAME"
+      #          --region "$AWS_REGION"  \
+      #          --no-confirm-changeset \
+      #          --no-fail-on-empty-changeset \
+      #          --capabilities CAPABILITY_NAMED_IAM,CAPABILITY_AUTO_EXPAND \
+      #          --tags DeploymentSource="GitHub Actions" StackType=Preview \
+      #          --parameter-overrides Environment="dev" SisStackName=preview-main
 
       - name: Deploy SAM Application
         timeout-minutes: 15
@@ -154,7 +154,7 @@ jobs:
             --no-fail-on-empty-changeset \
             --capabilities CAPABILITY_NAMED_IAM \
             --tags DeploymentSource="GitHub Actions" StackType=Preview \
-            --parameter-overrides Environment="dev"
+            --parameter-overrides Environment="dev" VpcStackName=vpc OauthInternalStackName=preview-main-oauth
 
       - name: Report deployment
         run: echo "Deployed stack \`$STACK_NAME\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-to-aws.yml
+++ b/.github/workflows/deploy-to-aws.yml
@@ -154,7 +154,7 @@ jobs:
             --no-fail-on-empty-changeset \
             --capabilities CAPABILITY_NAMED_IAM \
             --tags DeploymentSource="GitHub Actions" StackType=Preview \
-            --parameter-overrides Environment="dev" VpcStackName=vpc OauthInternalStackName=preview-main-oauth
+            --parameter-overrides Environment="dev" OauthInternalStackName=preview-main-oauth
 
       - name: Report deployment
         run: echo "Deployed stack \`$STACK_NAME\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -143,7 +143,7 @@
         "filename": "infrastructure/identity-reuse-service/template.yaml",
         "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
         "is_verified": false,
-        "line_number": 135,
+        "line_number": 140,
         "is_secret": false
       },
       {
@@ -151,7 +151,7 @@
         "filename": "infrastructure/identity-reuse-service/template.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
         "is_verified": false,
-        "line_number": 200,
+        "line_number": 205,
         "is_secret": false
       },
       {
@@ -159,7 +159,7 @@
         "filename": "infrastructure/identity-reuse-service/template.yaml",
         "hashed_secret": "aa1dd0ad4d2da161dd67db89e3d1aff921426385",
         "is_verified": false,
-        "line_number": 286,
+        "line_number": 291,
         "is_secret": false
       },
       {
@@ -167,7 +167,7 @@
         "filename": "infrastructure/identity-reuse-service/template.yaml",
         "hashed_secret": "5f784906cd85d6336c8506e9da9d102405771429",
         "is_verified": false,
-        "line_number": 292,
+        "line_number": 297,
         "is_secret": false
       },
       {
@@ -175,7 +175,7 @@
         "filename": "infrastructure/identity-reuse-service/template.yaml",
         "hashed_secret": "1ef0d2ac7a97bfe12f63f5d79979f912500adae1",
         "is_verified": false,
-        "line_number": 298,
+        "line_number": 303,
         "is_secret": false
       },
       {
@@ -183,7 +183,7 @@
         "filename": "infrastructure/identity-reuse-service/template.yaml",
         "hashed_secret": "5f399dc88587898510cf56b7503b482c870d0121",
         "is_verified": false,
-        "line_number": 304,
+        "line_number": 309,
         "is_secret": false
       },
       {
@@ -191,10 +191,10 @@
         "filename": "infrastructure/identity-reuse-service/template.yaml",
         "hashed_secret": "dc2050b23f4157e1b630f2bdf2f0a76b82f0f51a",
         "is_verified": false,
-        "line_number": 310,
+        "line_number": 315,
         "is_secret": false
       }
     ]
   },
-  "generated_at": "2026-06-12T12:37:06Z"
+  "generated_at": "2026-06-29T08:58:43Z"
 }

--- a/deploy-to-dev.sh
+++ b/deploy-to-dev.sh
@@ -165,7 +165,7 @@ if $DEPLOY_SIS; then
 
     if $DEPLOY_OAUTH; then
         OAUTH_STACK_NAME="$STACK_NAME-oauth-internal"
-    else
+    elif
         OAUTH_STACK_NAME="preview-main-oauth"
     fi
 elif $DEPLOY_OAUTH; then

--- a/deploy-to-dev.sh
+++ b/deploy-to-dev.sh
@@ -162,7 +162,12 @@ fi
 
 if $DEPLOY_SIS; then
   SIS_STACK_NAME=$STACK_NAME
-  OAUTH_STACK_NAME="$STACK_NAME-oauth-internal"
+
+    if $DEPLOY_OAUTH; then
+        OAUTH_STACK_NAME="$STACK_NAME-oauth-internal"
+    else
+        OAUTH_STACK_NAME="preview-main-oauth"
+    fi
 elif $DEPLOY_OAUTH; then
   OAUTH_STACK_NAME=$STACK_NAME
 else
@@ -184,7 +189,7 @@ $DEPLOY_OAUTH && echo "Deploy oauth-internal to stack $OAUTH_STACK_NAME, pointin
 echo
 
 if $DEPLOY_SIS; then
-  deploy_or_destroy "identity-reuse-service" "$SIS_STACK_NAME"
+  deploy_or_destroy "identity-reuse-service" "$SIS_STACK_NAME" "OauthInternalStackName=$OAUTH_STACK_NAME"
 fi
 if $DEPLOY_OAUTH; then
   deploy_or_destroy "oauth-internal" "$OAUTH_STACK_NAME" "SisStackName=$SIS_STACK_NAME"

--- a/infrastructure/identity-reuse-service/template.yaml
+++ b/infrastructure/identity-reuse-service/template.yaml
@@ -81,6 +81,11 @@ Parameters:
     Type: String
     Default: vpc
 
+  OauthInternalStackName:
+    Description: OAuth Internal Stack name
+    Type: String
+    Default: "oauth-internal"
+
   DynatraceNodeLayerArn:
     Type: String
     Description: The ARN of the OneAgent Node layer for Lambda Node functions
@@ -379,6 +384,8 @@ Resources:
           SQS_AUDIT_EVENT_QUEUE_URL: !Ref AuditEventQueue
           COMPONENT_ID: !Ref ComponentId
           DOMAIN_NAME: !Ref ReuseIdentityCustomDomain
+          OAUTH_INTERNAL_API_URL:
+            Fn::ImportValue: !Sub "${OauthInternalStackName}-OAuthInternalApi"
       CodeSigningConfigArn: !If
         - UseCodeSigning
         - !Ref CodeSigningConfigArn

--- a/infrastructure/identity-reuse-service/template.yaml
+++ b/infrastructure/identity-reuse-service/template.yaml
@@ -84,7 +84,7 @@ Parameters:
   OauthInternalStackName:
     Description: OAuth Internal Stack name
     Type: String
-    Default: "oauth-internal"
+    Default: "sis-oauth-internal"
 
   DynatraceNodeLayerArn:
     Type: String
@@ -385,7 +385,7 @@ Resources:
           COMPONENT_ID: !Ref ComponentId
           DOMAIN_NAME: !Ref ReuseIdentityCustomDomain
           OAUTH_INTERNAL_API_URL:
-            Fn::ImportValue: !Sub "${OauthInternalStackName}-OAuthInternalApi"
+            Fn::ImportValue: !Sub "${OauthInternalStackName}-PrivateApi"
       CodeSigningConfigArn: !If
         - UseCodeSigning
         - !Ref CodeSigningConfigArn

--- a/src/commons/environment.d.ts
+++ b/src/commons/environment.d.ts
@@ -3,10 +3,12 @@ declare namespace NodeJS {
   interface ProcessEnv {
     APP_CONFIG_APPLICATION: string;
     APP_CONFIG_NAME: string;
+    DOMAIN_NAME: string;
     ENVIRONMENT: string;
     EVCS_API_KEY_SECRET_ARN: string;
     POWERTOOLS_METRICS_NAMESPACE: string;
     POWERTOOLS_SERVICE_NAME: string;
+    OAUTH_INTERNAL_API_URL: string;
     SQS_AUDIT_EVENT_QUEUE_URL: string;
     DID_SIGNING_KEY_ARN: string;
     DID_CONTROLLER: string;

--- a/src/commons/get-required-environment.ts
+++ b/src/commons/get-required-environment.ts
@@ -1,0 +1,7 @@
+export const getRequiredEnvironment = (name: string): string => {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Environment variable ${name} must be defined`);
+  }
+  return value;
+};

--- a/src/commons/tests/get-required-environment.test.ts
+++ b/src/commons/tests/get-required-environment.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getRequiredEnvironment } from "../get-required-environment";
+
+const EXPECTED_ERROR = "Environment variable TEST_VAR must be defined";
+
+describe("getRequiredEnvironment", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("should return the value when the environment variable is set", () => {
+    vi.stubEnv("TEST_VAR", "hello");
+
+    const result = getRequiredEnvironment("TEST_VAR");
+
+    expect(result).toBe("hello");
+  });
+
+  it("should throw when the environment variable is not set", () => {
+    vi.stubEnv("TEST_VAR", undefined as unknown as string);
+
+    expect(() => getRequiredEnvironment("TEST_VAR")).toThrow(EXPECTED_ERROR);
+  });
+
+  it("should throw when the environment variable is an empty string", () => {
+    vi.stubEnv("TEST_VAR", "");
+
+    expect(() => getRequiredEnvironment("TEST_VAR")).toThrow(EXPECTED_ERROR);
+  });
+});

--- a/src/handlers/authorize-handler/authorize-handler.ts
+++ b/src/handlers/authorize-handler/authorize-handler.ts
@@ -39,15 +39,17 @@ function redirectToError(domainName: string): APIGatewayProxyResult {
   };
 }
 
-function redirectToConfirmDetails(domainName: string, sessionId: string): APIGatewayProxyResult {
+function redirectToConfirmDetails(domainName: string, sessionResponse: SessionResponse): APIGatewayProxyResult {
   const url = new URL("/confirm-details", `https://${domainName}`);
+  url.searchParams.append("state", sessionResponse.state);
+  url.searchParams.append("redirect_uri", sessionResponse.redirect_uri);
 
   return {
     statusCode: 302,
     body: "",
     headers: {
       Location: url.href,
-      "Set-Cookie": buildSessionCookie(sessionId),
+      "Set-Cookie": buildSessionCookie(sessionResponse.session_id),
     },
   };
 }
@@ -87,7 +89,6 @@ export async function handler(event: APIGatewayProxyEvent, context: Context): Pr
   }
 
   const url = new URL("/confirm-details", `https://${domainName}`);
-  url.searchParams.append("code", "SplxlOBeZQQYbYS6WxSbIA");
   url.searchParams.append("state", state);
   url.searchParams.append("redirect_uri", redirectUri);
 
@@ -116,7 +117,7 @@ async function createSession(clientId: string, request: string, domainName: stri
     return redirectToError(domainName);
   }
 
-  const { session_id: sessionId }: SessionResponse = await response.json();
+  const sessionResponse: SessionResponse = await response.json();
 
-  return redirectToConfirmDetails(domainName, sessionId);
+  return redirectToConfirmDetails(domainName, sessionResponse);
 }

--- a/src/handlers/authorize-handler/authorize-handler.ts
+++ b/src/handlers/authorize-handler/authorize-handler.ts
@@ -53,7 +53,7 @@ function redirectToConfirmDetails(domainName: string, sessionId: string): APIGat
 }
 
 async function callSessionApi(apiUrl: string, clientId: string, request: string): Promise<Response> {
-  const url = new URL("/api/session", apiUrl);
+  const url = new URL(`${apiUrl}/api/session`);
 
   const body = JSON.stringify({
     client_id: clientId,

--- a/src/handlers/authorize-handler/authorize-handler.ts
+++ b/src/handlers/authorize-handler/authorize-handler.ts
@@ -1,11 +1,7 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from "aws-lambda";
 import logger from "../../commons/logger";
+import { getRequiredEnvironment } from "../../commons/get-required-environment";
 import { URL } from "node:url";
-
-export type OAuthBadRequest = {
-  error: string;
-  error_description: string;
-};
 
 export type AuthorizationQueryStringParameters = {
   client_id: string;
@@ -16,13 +12,81 @@ export type AuthorizationQueryStringParameters = {
   request?: string;
 };
 
-export const handler = async (event: APIGatewayProxyEvent, context: Context): Promise<APIGatewayProxyResult> => {
+type SessionResponse = {
+  session_id: string;
+  state: string;
+  redirect_uri: string;
+};
+
+const SESSION_TIMEOUT_MS = 10_000;
+const SESSION_COOKIE_NAME = "identity_reuse_service_session";
+
+function buildSessionCookie(sessionId: string): string {
+  const value = `${SESSION_COOKIE_NAME}=${sessionId}`;
+  const attributes = "Path=/; Secure; HttpOnly; SameSite=Lax";
+  return `${value}; ${attributes}`;
+}
+
+function redirectToError(domainName: string): APIGatewayProxyResult {
+  const url = new URL("/error/unrecoverable", `https://${domainName}`);
+
+  return {
+    statusCode: 302,
+    body: "",
+    headers: {
+      Location: url.href,
+    },
+  };
+}
+
+function redirectToConfirmDetails(domainName: string, sessionId: string): APIGatewayProxyResult {
+  const url = new URL("/confirm-details", `https://${domainName}`);
+
+  return {
+    statusCode: 302,
+    body: "",
+    headers: {
+      Location: url.href,
+      "Set-Cookie": buildSessionCookie(sessionId),
+    },
+  };
+}
+
+async function callSessionApi(apiUrl: string, clientId: string, request: string): Promise<Response> {
+  const url = new URL("/api/session", apiUrl);
+
+  const body = JSON.stringify({
+    client_id: clientId,
+    request,
+  });
+
+  return fetch(url.href, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body,
+    signal: AbortSignal.timeout(SESSION_TIMEOUT_MS),
+  });
+}
+
+export async function handler(event: APIGatewayProxyEvent, context: Context): Promise<APIGatewayProxyResult> {
   logger.addContext(context);
 
-  const { redirect_uri: redirectUri, state } = event.queryStringParameters as AuthorizationQueryStringParameters;
+  const {
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    state,
+    request,
+  } = event.queryStringParameters as AuthorizationQueryStringParameters;
 
-  const domainName = process.env.DOMAIN_NAME || "";
-  const url = new URL(`https://${domainName}/confirm-details`);
+  const domainName = getRequiredEnvironment("DOMAIN_NAME");
+
+  if (request) {
+    return createSession(clientId, request, domainName);
+  }
+
+  const url = new URL("/confirm-details", `https://${domainName}`);
   url.searchParams.append("code", "SplxlOBeZQQYbYS6WxSbIA");
   url.searchParams.append("state", state);
   url.searchParams.append("redirect_uri", redirectUri);
@@ -34,4 +98,25 @@ export const handler = async (event: APIGatewayProxyEvent, context: Context): Pr
       Location: url.href,
     },
   };
-};
+}
+
+async function createSession(clientId: string, request: string, domainName: string): Promise<APIGatewayProxyResult> {
+  const oauthInternalApiUrl = getRequiredEnvironment("OAUTH_INTERNAL_API_URL");
+
+  let response: Response;
+  try {
+    response = await callSessionApi(oauthInternalApiUrl, clientId, request);
+  } catch (error) {
+    logger.error(`Error calling session handler: ${error}`);
+    return redirectToError(domainName);
+  }
+
+  if (response.status !== 201) {
+    logger.error(`Session handler returned non-201 status: ${response.status}`);
+    return redirectToError(domainName);
+  }
+
+  const { session_id: sessionId }: SessionResponse = await response.json();
+
+  return redirectToConfirmDetails(domainName, sessionId);
+}

--- a/src/handlers/authorize-handler/tests/authorize-handler.test.ts
+++ b/src/handlers/authorize-handler/tests/authorize-handler.test.ts
@@ -18,7 +18,7 @@ describe("authorize-handler", () => {
   });
 
   describe("when request param is absent", () => {
-    it("should return 302 with hardcoded auth code", async () => {
+    it("should return 302 with redirect_uri and state", async () => {
       const event = createMockEvent({
         queryStringParameters: {
           client_id: "sample",
@@ -32,8 +32,7 @@ describe("authorize-handler", () => {
 
       const expectedLocation = [
         "https://test-domain/confirm-details",
-        "?code=SplxlOBeZQQYbYS6WxSbIA",
-        "&state=test-state",
+        "?state=test-state",
         "&redirect_uri=https%3A%2F%2Fsome.redirect.com",
       ].join("");
 
@@ -56,8 +55,7 @@ describe("authorize-handler", () => {
 
       const expectedLocation = [
         "https://test-domain/confirm-details",
-        "?code=SplxlOBeZQQYbYS6WxSbIA",
-        "&state=test-state",
+        "?state=test-state",
         "&redirect_uri=https%253A%252F%252Fsome.redirect.com%252Fcallback",
       ].join("");
 
@@ -103,7 +101,9 @@ describe("authorize-handler", () => {
 
       expect(response.statusCode).toBe(302);
 
-      expect(response.headers?.Location).toBe("https://test-domain/confirm-details");
+      expect(response.headers?.Location).toBe(
+        "https://test-domain/confirm-details?state=test-state&redirect_uri=https%3A%2F%2Fsome.redirect.com"
+      );
 
       const expectedCookie = [
         "identity_reuse_service_session=session-abc-123",

--- a/src/handlers/authorize-handler/tests/authorize-handler.test.ts
+++ b/src/handlers/authorize-handler/tests/authorize-handler.test.ts
@@ -1,69 +1,208 @@
 import { APIGatewayEventRequestContextWithAuthorizer, APIGatewayProxyEvent, Context } from "aws-lambda";
-import { expect, it } from "vitest";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { AuthorizationQueryStringParameters, handler } from "../authorize-handler";
 
 process.env.DOMAIN_NAME = "test-domain";
+process.env.OAUTH_INTERNAL_API_URL = "https://example.com";
 
-it("should return 302 status code on a successful request", async () => {
-  const event = createMockAPIGatewayProxyEvent({
-    queryStringParameters: {
-      client_id: "sample",
-      response_type: "code",
-      redirect_uri: "https://api.example.com/callback",
-      state: "test-state",
-      request: "test.1234.5678",
-    } satisfies AuthorizationQueryStringParameters,
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("authorize-handler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
   });
 
-  const response = await handler(event, {} as Context);
-  expect(response).toStrictEqual({
-    statusCode: 302,
-    body: "",
-    headers: {
-      Location:
-        "https://test-domain/confirm-details?code=SplxlOBeZQQYbYS6WxSbIA&state=test-state&redirect_uri=https%3A%2F%2Fapi.example.com%2Fcallback",
-    },
+  describe("when request param is absent", () => {
+    it("should return 302 with hardcoded auth code", async () => {
+      const event = createMockEvent({
+        queryStringParameters: {
+          client_id: "sample",
+          response_type: "code",
+          redirect_uri: "https://some.redirect.com",
+          state: "test-state",
+        } satisfies AuthorizationQueryStringParameters,
+      });
+
+      const response = await handler(event, {} as Context);
+
+      const expectedLocation = [
+        "https://test-domain/confirm-details",
+        "?code=SplxlOBeZQQYbYS6WxSbIA",
+        "&state=test-state",
+        "&redirect_uri=https%3A%2F%2Fsome.redirect.com",
+      ].join("");
+
+      expect(response.statusCode).toBe(302);
+      expect(response.headers?.Location).toBe(expectedLocation);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("should handle URL encoded redirect_uri", async () => {
+      const event = createMockEvent({
+        queryStringParameters: {
+          client_id: "sample",
+          response_type: "code",
+          redirect_uri: "https%3A%2F%2Fsome.redirect.com%2Fcallback",
+          state: "test-state",
+        } satisfies AuthorizationQueryStringParameters,
+      });
+
+      const response = await handler(event, {} as Context);
+
+      const expectedLocation = [
+        "https://test-domain/confirm-details",
+        "?code=SplxlOBeZQQYbYS6WxSbIA",
+        "&state=test-state",
+        "&redirect_uri=https%253A%252F%252Fsome.redirect.com%252Fcallback",
+      ].join("");
+
+      expect(response.statusCode).toBe(302);
+      expect(response.headers?.Location).toBe(expectedLocation);
+    });
+  });
+
+  describe("when request param is present", () => {
+    it("should redirect to confirm-details with session cookie on 201", async () => {
+      mockFetch.mockResolvedValue({
+        status: 201,
+        json: async () => ({
+          session_id: "session-abc-123",
+          state: "test-state",
+          redirect_uri: "https://some.redirect.com",
+        }),
+      });
+
+      const event = createMockEvent({
+        queryStringParameters: {
+          client_id: "orchestrator",
+          response_type: "code",
+          redirect_uri: "https://some.redirect.com",
+          state: "test-state",
+          request: "foo.bar.123",
+        } satisfies AuthorizationQueryStringParameters,
+      });
+
+      const response = await handler(event, {} as Context);
+
+      expect(mockFetch).toHaveBeenCalledWith("https://example.com/api/session", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          client_id: "orchestrator",
+          request: "foo.bar.123",
+        }),
+        signal: expect.any(AbortSignal),
+      });
+
+      expect(response.statusCode).toBe(302);
+
+      expect(response.headers?.Location).toBe("https://test-domain/confirm-details");
+
+      const expectedCookie = [
+        "identity_reuse_service_session=session-abc-123",
+        "Path=/",
+        "Secure",
+        "HttpOnly",
+        "SameSite=Lax",
+      ].join("; ");
+
+      expect(response.headers?.["Set-Cookie"]).toBe(expectedCookie);
+    });
+
+    it("should redirect to error page when session handler returns 400", async () => {
+      mockFetch.mockResolvedValue({
+        status: 400,
+      });
+
+      const event = createMockEvent({
+        queryStringParameters: {
+          client_id: "orchestrator",
+          response_type: "code",
+          redirect_uri: "https://some.redirect.com",
+          state: "test-state",
+          request: "invalid.jar.content",
+        } satisfies AuthorizationQueryStringParameters,
+      });
+
+      const response = await handler(event, {} as Context);
+
+      expect(response.statusCode).toBe(302);
+
+      expect(response.headers?.Location).toBe("https://test-domain/error/unrecoverable");
+
+      expect(response.headers?.["Set-Cookie"]).toBeUndefined();
+    });
+
+    it("should redirect to error page when session handler returns 500", async () => {
+      mockFetch.mockResolvedValue({
+        status: 500,
+      });
+
+      const event = createMockEvent({
+        queryStringParameters: {
+          client_id: "orchestrator",
+          response_type: "code",
+          redirect_uri: "https://some.redirect.com",
+          state: "test-state",
+          request: "some.jar.value",
+        } satisfies AuthorizationQueryStringParameters,
+      });
+
+      const response = await handler(event, {} as Context);
+
+      expect(response.statusCode).toBe(302);
+
+      expect(response.headers?.Location).toBe("https://test-domain/error/unrecoverable");
+    });
+
+    it("should redirect to error page when fetch throws", async () => {
+      mockFetch.mockRejectedValue(new Error("ECONNREFUSED"));
+
+      const event = createMockEvent({
+        queryStringParameters: {
+          client_id: "orchestrator",
+          response_type: "code",
+          redirect_uri: "https://some.redirect.com",
+          state: "test-state",
+          request: "some.jar.value",
+        } satisfies AuthorizationQueryStringParameters,
+      });
+
+      const response = await handler(event, {} as Context);
+
+      expect(response.statusCode).toBe(302);
+
+      expect(response.headers?.Location).toBe("https://test-domain/error/unrecoverable");
+    });
   });
 });
 
-it("should return 302 status code on a successful request and handle URL encoded redirect_uri", async () => {
-  const event = createMockAPIGatewayProxyEvent({
-    queryStringParameters: {
-      client_id: "sample",
-      response_type: "code",
-      redirect_uri: "https%3A%2F%2Fapi.example.com%2Fcallback",
-      state: "test-state",
-    } satisfies AuthorizationQueryStringParameters,
-  });
-
-  const response = await handler(event, {} as Context);
-  expect(response).toStrictEqual({
-    statusCode: 302,
-    body: "",
-    headers: {
-      Location:
-        "https://test-domain/confirm-details?code=SplxlOBeZQQYbYS6WxSbIA&state=test-state&redirect_uri=https%253A%252F%252Fapi.example.com%252Fcallback",
-    },
-  });
-});
-
-const createMockAPIGatewayProxyEvent = (event: Partial<APIGatewayProxyEvent>): APIGatewayProxyEvent => ({
-  // eslint-disable-next-line unicorn/no-null -- Required to create value APIGatewayProxyEvent object
-  body: null,
-  headers: {},
-  multiValueHeaders: {},
-  httpMethod: "GET",
-  isBase64Encoded: false,
-  path: "/",
-  // eslint-disable-next-line unicorn/no-null -- Required to create value APIGatewayProxyEvent object
-  pathParameters: null,
-  // eslint-disable-next-line unicorn/no-null -- Required to create value APIGatewayProxyEvent object
-  queryStringParameters: null,
-  // eslint-disable-next-line unicorn/no-null -- Required to create value APIGatewayProxyEvent object
-  multiValueQueryStringParameters: null,
-  // eslint-disable-next-line unicorn/no-null -- Required to create value APIGatewayProxyEvent object
-  stageVariables: null,
-  requestContext: {} as APIGatewayEventRequestContextWithAuthorizer<never>,
-  resource: "/",
-  ...event,
-});
+function createMockEvent(overrides: Partial<APIGatewayProxyEvent>): APIGatewayProxyEvent {
+  return {
+    // eslint-disable-next-line unicorn/no-null
+    body: null,
+    headers: {},
+    multiValueHeaders: {},
+    httpMethod: "GET",
+    isBase64Encoded: false,
+    path: "/",
+    // eslint-disable-next-line unicorn/no-null
+    pathParameters: null,
+    // eslint-disable-next-line unicorn/no-null
+    queryStringParameters: null,
+    // eslint-disable-next-line unicorn/no-null
+    multiValueQueryStringParameters: null,
+    // eslint-disable-next-line unicorn/no-null
+    stageVariables: null,
+    requestContext: {} as APIGatewayEventRequestContextWithAuthorizer<never>,
+    resource: "/",
+    ...overrides,
+  };
+}

--- a/src/handlers/authorize-handler/tests/authorize-handler.test.ts
+++ b/src/handlers/authorize-handler/tests/authorize-handler.test.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { AuthorizationQueryStringParameters, handler } from "../authorize-handler";
 
 process.env.DOMAIN_NAME = "test-domain";
-process.env.OAUTH_INTERNAL_API_URL = "https://example.com";
+process.env.OAUTH_INTERNAL_API_URL = "https://example.com/v1";
 
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
@@ -89,7 +89,7 @@ describe("authorize-handler", () => {
 
       const response = await handler(event, {} as Context);
 
-      expect(mockFetch).toHaveBeenCalledWith("https://example.com/api/session", {
+      expect(mockFetch).toHaveBeenCalledWith("https://example.com/v1/api/session", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/src/handlers/confirm-details/confirm-details-handler.ts
+++ b/src/handlers/confirm-details/confirm-details-handler.ts
@@ -8,14 +8,13 @@ const govukFrontendDistribution = path.join(path.dirname(require.resolve("govuk-
 const nunjucksEnvironment = nunjucks.configure([process.env.LAMBDA_TASK_ROOT || "", govukFrontendDistribution]);
 
 export type ConfirmDetailsQueryStringParameters = {
-  code: string;
   redirect_uri: string;
   state: string;
 };
 
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
-  const { code, redirect_uri, state } = event.queryStringParameters as ConfirmDetailsQueryStringParameters;
-  if (!code || !redirect_uri || !state) {
+  const { redirect_uri, state } = event.queryStringParameters as ConfirmDetailsQueryStringParameters;
+  if (!redirect_uri || !state) {
     throw new Error("One or more required query string parameters are undefined or empty");
   }
   try {
@@ -24,7 +23,6 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
       body: nunjucksEnvironment.render(mainPageTemplate, {
         assetPath: "./assets",
         rootPath: ".",
-        code,
         redirect_uri,
         state,
       }),

--- a/src/handlers/confirm-details/confirm-details-submission-handler.ts
+++ b/src/handlers/confirm-details/confirm-details-submission-handler.ts
@@ -5,15 +5,14 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
   const eventValues = new URLSearchParams(event.body || "");
 
   const redirectUri = eventValues.get("redirectUri");
-  const code = eventValues.get("code");
   const state = eventValues.get("state");
 
-  if (!redirectUri || !code || !state) {
+  if (!redirectUri || !state) {
     throw new Error("One or more required query string parameters are undefined");
   }
 
   const url = new URL(decodeURIComponent(eventValues.get("redirectUri") || ""));
-  url.searchParams.append("code", eventValues.get("code") || "");
+  url.searchParams.append("code", "SplxlOBeZQQYbYS6WxSbIA");
   url.searchParams.append("state", eventValues.get("state") || "");
 
   try {

--- a/src/handlers/confirm-details/tests/confirm-details-handler.test.ts
+++ b/src/handlers/confirm-details/tests/confirm-details-handler.test.ts
@@ -22,7 +22,6 @@ it("should render the confirm details screen when all query string parameters ar
   const result = await lambdaHandler({
     queryStringParameters: {
       redirect_uri: "https://example.com",
-      code: "1234",
       state: "state-id",
     },
   } as never as APIGatewayProxyEvent);
@@ -32,7 +31,6 @@ it("should render the confirm details screen when all query string parameters ar
     {
       assetPath: "./assets",
       redirect_uri: "https://example.com",
-      code: "1234",
       state: "state-id",
       rootPath: ".",
     }

--- a/src/handlers/confirm-details/tests/confirm-details-submission-handler.test.ts
+++ b/src/handlers/confirm-details/tests/confirm-details-submission-handler.test.ts
@@ -3,17 +3,14 @@ import { expect, it } from "vitest";
 import { lambdaHandler } from "../confirm-details-submission-handler";
 
 it("should return a 302 status code on a successful request", async () => {
-  const event = createMockAPIGatewayProxyEvent(
-    {},
-    "redirectUri=https%3A%2F%2Fapi.example.com&code=abc123&state=test-state-id"
-  );
+  const event = createMockAPIGatewayProxyEvent({}, "redirectUri=https%3A%2F%2Fapi.example.com&state=test-state-id");
 
   const response = await lambdaHandler(event);
   expect(response).toStrictEqual({
     statusCode: 302,
     body: "",
     headers: {
-      Location: "https://api.example.com/?code=abc123&state=test-state-id",
+      Location: "https://api.example.com/?code=SplxlOBeZQQYbYS6WxSbIA&state=test-state-id",
     },
   });
 });

--- a/tests/acceptance/steps/authorization.step.ts
+++ b/tests/acceptance/steps/authorization.step.ts
@@ -37,18 +37,15 @@ Then<WorldDefinition>(
       this.authorizationResponse.origin = domainName!;
     }
     assert.ok(isAuthorizationResponse(this.authorizationResponse));
-    assert.ok(this.authorizationResponse.code);
     assert.equal(this.authorizationResponse.origin, domainName);
   }
 );
 
 When<WorldDefinition>("I call the token endpoint with the authorization code", async function () {
   assert.ok(isAuthorizationResponse(this.authorizationResponse));
-  assert.ok(this.authorizationResponse.code);
-
   this.tokenResponse = await token({
     grant_type: TokenGrantType.AuthorizationCode,
-    code: this.authorizationResponse.code,
+    code: "SplxlOBeZQQYbYS6WxSbIA",
   });
 });
 


### PR DESCRIPTION
## What

- Validate JAR and create session on call to /authorize

## Why

- In order to enable SIS to make use of Common OAuth components, SIS and it’s Orchestration stub will require updates to integrate into the OAuth flow.



