### PR TITLE
SPT-1999: Update the SIS API spec

### DIFF
--- a/openAPI/private-api.yaml
+++ b/openAPI/private-api.yaml
@@ -97,12 +97,30 @@ components:
   schemas:
     TokenRequestBody:
       type: object
+      required:
+        - grant_type
+        - code
+        - client_assertion_type
+        - client_assertion
+        - redirect_uri
       properties:
         grant_type:
           type: string
-          enum: ["authorization_code"]
+          pattern: "authorization_code"
+          example: "authorization_code"
         code:
           type: string
+          minLength: 1
+        client_assertion_type:
+          type: string
+          pattern: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+          example: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+        client_assertion:
+          type: string
+          pattern: "[a-zA-Z0-9_=]+\\.[a-zA-Z0-9_=]+\\.[a-zA-Z0-9_\\-\\+\\/=]+"
+        redirect_uri:
+          type: string
+          format: "uri"
     TokenResponseBody:
       type: object
       properties:


### PR DESCRIPTION
## What

- SPT-1999
- Update the `/token` endpoint to include extra parameters 

## Why

<!-- Describe the reason these changes were made - the "why" -->
<!-- Include all information the reviewer needs for context -->

- In order to enable SIS to make use of Common OAuth components, SIS and it’s Orchestration stub will require updates to integrate into the OAuth flow.
