### PR TITLE
SPT-1950: Ensure the publish actions use the correct GHA env

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -120,7 +120,6 @@ jobs:
       aws-role-arn: ${{ secrets.GHA_AWS_ROLE_ARN }}
       ecr-repository: ${{ secrets.TEST_IMAGE_ECR_REPOSITORY }}
 
-
   publish-oauth:
     uses: ./.github/workflows/publish.yml
     needs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,11 @@ on:
         default: built-code
         required: false
         type: string
+      environment:
+        description: The name of the GitHub environment to use for publishing
+        default: build
+        required: false
+        type: string
     secrets:
       aws-role-arn:
         description: >
@@ -33,6 +38,7 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
## What

Add an optional input to the `publish` workflow to allow the correct GitHub deployment environment to be specified (this ensure the appropriate version of secrets are accessed).

This should default to `build` but could be overridden where required.

## Why

The publish OAuth step is failing because it doesn't have access to the secrets which were added to the `build` environment. (in the main SIS publish step the secrets have been erroneously added at both the repo and environment level, hence that has been working, this will be tidied up outside of this PR).

## Related PRs

#361 