### PR TITLE
SPT-1949: Fix skeleton OAuth acceptance tests

### DIFF
--- a/tests/acceptance/features/authorization-workflow.feature
+++ b/tests/acceptance/features/authorization-workflow.feature
@@ -1,10 +1,12 @@
 Feature: authorization-workflow.feature
 
   Scenario: I should be able to complete an authorization flow and request my user-identity
-    Given I have a user profile
-    When I call the authorize endpoint, with the redirect URI "https://api.example.com"
-    Then I will be issued with an authorization code and redirected to the confirm details page
-    When I call the token endpoint with the authorization code
-    Then I will be issued with an authorization token
-    When I call the user-identity endpoint
-    Then I will be issued with my user-identity
+    Given a user has a profile
+    When the client calls the authorize endpoint, with the redirect URI "https://api.example.com" and state "sample-state"
+    Then the user will be redirected to the confirm details page
+    When the user clicks Continue
+    Then the user will be redirected to the client's redirect URI with an authorization code
+    When the client calls the token endpoint with the authorization code
+    Then the client will be issued with an authorization token
+    When the client calls the user-identity endpoint with the authorization token
+    Then the user-identity will be returned to the client

--- a/tests/acceptance/features/authorization-workflow.feature
+++ b/tests/acceptance/features/authorization-workflow.feature
@@ -5,7 +5,7 @@ Feature: authorization-workflow.feature
     When the client calls the authorize endpoint, with the redirect URI "https://api.example.com" and state "sample-state"
     Then the user will be redirected to the confirm details page
     When the user clicks Continue
-    Then the user will be redirected to the client's redirect URI with an authorization code
+    Then the user will be redirected to the client's redirect URI with an authorization code and the state
     When the client calls the token endpoint with the authorization code
     Then the client will be issued with an access token
     When the client calls the user-identity endpoint with the access token

--- a/tests/acceptance/features/authorization-workflow.feature
+++ b/tests/acceptance/features/authorization-workflow.feature
@@ -7,6 +7,6 @@ Feature: authorization-workflow.feature
     When the user clicks Continue
     Then the user will be redirected to the client's redirect URI with an authorization code
     When the client calls the token endpoint with the authorization code
-    Then the client will be issued with an authorization token
-    When the client calls the user-identity endpoint with the authorization token
+    Then the client will be issued with an access token
+    When the client calls the user-identity endpoint with the access token
     Then the user-identity will be returned to the client

--- a/tests/acceptance/steps/authorization.step.ts
+++ b/tests/acceptance/steps/authorization.step.ts
@@ -40,6 +40,7 @@ Then<WorldDefinition>("the user will be redirected to the confirm details page",
   assertRedirectResponse(this.redirectResponse);
   assert.ok(isRedirectResponse(this.redirectResponse));
   assert.equal(this.redirectResponse.origin, domainName);
+  assert.equal(this.redirectResponse.pathname, "/confirm-details");
 });
 
 When<WorldDefinition>("the user clicks Continue", async function () {

--- a/tests/acceptance/steps/authorization.step.ts
+++ b/tests/acceptance/steps/authorization.step.ts
@@ -3,6 +3,7 @@ import { WorldDefinition } from "./base-verbs.step";
 import {
   AuthorizationResponseType,
   authorize,
+  confirmDetailsSubmission,
   isAuthorizationResponse,
   isTokenResponse,
   token,
@@ -11,37 +12,49 @@ import {
 import assert from "node:assert";
 import { sisGetUserIdentityHandler } from "./utils/sis-api";
 
-Given<WorldDefinition>("I have a user profile", function () {
+Given<WorldDefinition>("a user has a profile", function () {
   // Do nothing, this is currently a placeholder with a verb to make it clear
   // what may be happening. In the future it's expected that this will set up
   // user credentials.
 });
 
 When<WorldDefinition>(
-  "I call the authorize endpoint, with the redirect URI {string}",
-  async function (redirectUri: string) {
+  "the client calls the authorize endpoint, with the redirect URI {string} and state {string}",
+  async function (redirectUri: string, state: string) {
+    this.redirectUri = redirectUri;
+    this.state = state;
     this.authorizationResponse = await authorize({
       client_id: "acceptance-tests",
-      state: "acceptance-tests",
+      state: state,
       response_type: AuthorizationResponseType.code,
       redirect_uri: redirectUri,
     });
   }
 );
 
+Then<WorldDefinition>("the user will be redirected to the confirm details page", function () {
+  const domainName = process.env.DOMAIN_NAME;
+  if ("origin" in this.authorizationResponse!) {
+    this.authorizationResponse.origin = domainName!;
+  }
+  assert.ok(isAuthorizationResponse(this.authorizationResponse));
+  assert.equal(this.authorizationResponse.origin, domainName);
+});
+
+When<WorldDefinition>("the user clicks Continue", async function () {
+  this.authorizationResponse = await confirmDetailsSubmission(this.redirectUri!, this.state!);
+});
+
 Then<WorldDefinition>(
-  "I will be issued with an authorization code and redirected to the confirm details page",
-  function () {
-    const domainName = process.env.DOMAIN_NAME;
-    if ("origin" in this.authorizationResponse!) {
-      this.authorizationResponse.origin = domainName!;
-    }
+  "the user will be redirected to the client's redirect URI with an authorization code",
+  async function () {
     assert.ok(isAuthorizationResponse(this.authorizationResponse));
-    assert.equal(this.authorizationResponse.origin, domainName);
+    assert.equal(this.authorizationResponse.origin, "https://api.example.com");
+    assert.ok(this.authorizationResponse.code, "Expected an authorization code but got none");
   }
 );
 
-When<WorldDefinition>("I call the token endpoint with the authorization code", async function () {
+When<WorldDefinition>("the client calls the token endpoint with the authorization code", async function () {
   assert.ok(isAuthorizationResponse(this.authorizationResponse));
   this.tokenResponse = await token({
     grant_type: TokenGrantType.AuthorizationCode,
@@ -49,13 +62,13 @@ When<WorldDefinition>("I call the token endpoint with the authorization code", a
   });
 });
 
-Then<WorldDefinition>("I will be issued with an authorization token", function () {
+Then<WorldDefinition>("the client will be issued with an authorization token", function () {
   assert.ok(isTokenResponse(this.tokenResponse));
   assert.ok(this.tokenResponse.access_token);
   assert.equal(this.tokenResponse.token_type, "Bearer");
 });
 
-When<WorldDefinition>("I call the user-identity endpoint", async function () {
+When<WorldDefinition>("the client calls the user-identity endpoint with the authorization token", async function () {
   assert.ok(isTokenResponse(this.tokenResponse));
 
   this.userIdentityPostResponse = await sisGetUserIdentityHandler(
@@ -67,7 +80,7 @@ When<WorldDefinition>("I call the user-identity endpoint", async function () {
   );
 });
 
-Then<WorldDefinition>("I will be issued with my user-identity", function () {
+Then<WorldDefinition>("the user-identity will be returned to the client", function () {
   assert.ok(this.userIdentityPostResponse);
   assert.deepEqual(this.userIdentityPostResponse.body, {
     sub: "urn:fdc:gov.uk:2022:TEST_USER-7B96ScRg2a-k7fN-u-sZbEjbB3hQ6gf6SM0x",

--- a/tests/acceptance/steps/authorization.step.ts
+++ b/tests/acceptance/steps/authorization.step.ts
@@ -62,13 +62,13 @@ When<WorldDefinition>("the client calls the token endpoint with the authorizatio
   });
 });
 
-Then<WorldDefinition>("the client will be issued with an authorization token", function () {
+Then<WorldDefinition>("the client will be issued with an access token", function () {
   assert.ok(isTokenResponse(this.tokenResponse));
   assert.ok(this.tokenResponse.access_token);
   assert.equal(this.tokenResponse.token_type, "Bearer");
 });
 
-When<WorldDefinition>("the client calls the user-identity endpoint with the authorization token", async function () {
+When<WorldDefinition>("the client calls the user-identity endpoint with the access token", async function () {
   assert.ok(isTokenResponse(this.tokenResponse));
 
   this.userIdentityPostResponse = await sisGetUserIdentityHandler(

--- a/tests/acceptance/steps/authorization.step.ts
+++ b/tests/acceptance/steps/authorization.step.ts
@@ -7,11 +7,13 @@ import {
   isAuthorizationResponse,
   isRedirectResponse,
   isTokenResponse,
+  RedirectResponse,
   token,
   TokenGrantType,
 } from "./utils/auth-api";
 import assert from "node:assert";
 import { sisGetUserIdentityHandler } from "./utils/sis-api";
+import { CloudFormationOutputs, getCloudFormationOutput } from "./utils/cloudformation";
 
 Given<WorldDefinition>("a user has a profile", function () {
   // Do nothing, this is currently a placeholder with a verb to make it clear
@@ -33,11 +35,9 @@ When<WorldDefinition>(
   }
 );
 
-Then<WorldDefinition>("the user will be redirected to the confirm details page", function () {
-  const domainName = process.env.DOMAIN_NAME;
-  if ("origin" in this.redirectResponse!) {
-    this.redirectResponse.origin = domainName!;
-  }
+Then<WorldDefinition>("the user will be redirected to the confirm details page", async function () {
+  const domainName = await getCloudFormationOutput(CloudFormationOutputs.SisPublicApi);
+  assertRedirectResponse(this.redirectResponse);
   assert.ok(isRedirectResponse(this.redirectResponse));
   assert.equal(this.redirectResponse.origin, domainName);
 });
@@ -92,3 +92,7 @@ Then<WorldDefinition>("the user-identity will be returned to the client", functi
     vtm: "https://oidc.account.gov.uk/trustmark",
   });
 });
+
+function assertRedirectResponse(value: unknown): asserts value is RedirectResponse {
+  assert.ok(isRedirectResponse(value));
+}

--- a/tests/acceptance/steps/authorization.step.ts
+++ b/tests/acceptance/steps/authorization.step.ts
@@ -5,6 +5,7 @@ import {
   authorize,
   confirmDetailsSubmission,
   isAuthorizationResponse,
+  isRedirectResponse,
   isTokenResponse,
   token,
   TokenGrantType,
@@ -23,7 +24,7 @@ When<WorldDefinition>(
   async function (redirectUri: string, state: string) {
     this.redirectUri = redirectUri;
     this.state = state;
-    this.authorizationResponse = await authorize({
+    this.redirectResponse = await authorize({
       client_id: "acceptance-tests",
       state: state,
       response_type: AuthorizationResponseType.code,
@@ -34,11 +35,11 @@ When<WorldDefinition>(
 
 Then<WorldDefinition>("the user will be redirected to the confirm details page", function () {
   const domainName = process.env.DOMAIN_NAME;
-  if ("origin" in this.authorizationResponse!) {
-    this.authorizationResponse.origin = domainName!;
+  if ("origin" in this.redirectResponse!) {
+    this.redirectResponse.origin = domainName!;
   }
-  assert.ok(isAuthorizationResponse(this.authorizationResponse));
-  assert.equal(this.authorizationResponse.origin, domainName);
+  assert.ok(isRedirectResponse(this.redirectResponse));
+  assert.equal(this.redirectResponse.origin, domainName);
 });
 
 When<WorldDefinition>("the user clicks Continue", async function () {
@@ -46,10 +47,11 @@ When<WorldDefinition>("the user clicks Continue", async function () {
 });
 
 Then<WorldDefinition>(
-  "the user will be redirected to the client's redirect URI with an authorization code",
+  "the user will be redirected to the client's redirect URI with an authorization code and the state",
   async function () {
     assert.ok(isAuthorizationResponse(this.authorizationResponse));
-    assert.equal(this.authorizationResponse.origin, "https://api.example.com");
+    assert.equal(this.authorizationResponse.origin, this.redirectUri);
+    assert.equal(this.authorizationResponse.state, this.state);
     assert.ok(this.authorizationResponse.code, "Expected an authorization code but got none");
   }
 );
@@ -58,7 +60,7 @@ When<WorldDefinition>("the client calls the token endpoint with the authorizatio
   assert.ok(isAuthorizationResponse(this.authorizationResponse));
   this.tokenResponse = await token({
     grant_type: TokenGrantType.AuthorizationCode,
-    code: "SplxlOBeZQQYbYS6WxSbIA",
+    code: this.authorizationResponse.code!,
   });
 });
 

--- a/tests/acceptance/steps/base-verbs.step.ts
+++ b/tests/acceptance/steps/base-verbs.step.ts
@@ -2,21 +2,22 @@ import { setDefaultTimeout, Before, defineParameterType } from "@cucumber/cucumb
 import { Response } from "superagent";
 import { randomString } from "../../../shared-test/string-utilities";
 import { getDidControllerName, getSigningKeyId } from "./utils/ssm-utilities";
-import { AuthorizationResponse, OAuthBadRequest, TokenResponse } from "./utils/auth-api";
+import { AuthorizationResponse, OAuthBadRequest, RedirectResponse, TokenResponse } from "./utils/auth-api";
 
 export type WorldDefinition = {
   testDidController: string;
   keyId: string;
   userId: string;
   bearerToken?: string;
+  redirectUri?: string;
+  state?: string;
   requestedVtr: string[];
   govukSigninJourneyId: string;
   credentialJwts: string[];
   userIdentityPostResponse?: Response;
+  redirectResponse?: RedirectResponse | OAuthBadRequest;
   authorizationResponse?: AuthorizationResponse | OAuthBadRequest;
   tokenResponse?: TokenResponse | OAuthBadRequest;
-  redirectUri?: string;
-  state?: string;
 };
 
 setDefaultTimeout(20_000);
@@ -30,14 +31,15 @@ defineParameterType({
 Before<WorldDefinition>(async function () {
   this.userId = generateRandomTestUserId();
   this.govukSigninJourneyId = randomString(12);
+  this.redirectUri = undefined;
+  this.state = undefined;
   this.requestedVtr = ["P2"];
   this.credentialJwts = [];
   this.testDidController = await getDidControllerName();
   this.keyId = await getSigningKeyId();
+  this.redirectResponse = undefined;
   this.authorizationResponse = undefined;
   this.tokenResponse = undefined;
-  this.redirectUri = undefined;
-  this.state = undefined;
 });
 
 function generateRandomTestUserId() {

--- a/tests/acceptance/steps/base-verbs.step.ts
+++ b/tests/acceptance/steps/base-verbs.step.ts
@@ -15,7 +15,7 @@ export type WorldDefinition = {
   govukSigninJourneyId: string;
   credentialJwts: string[];
   userIdentityPostResponse?: Response;
-  redirectResponse?: RedirectResponse | OAuthBadRequest;
+  redirectResponse?: RedirectResponse | Error;
   authorizationResponse?: AuthorizationResponse | OAuthBadRequest;
   tokenResponse?: TokenResponse | OAuthBadRequest;
 };

--- a/tests/acceptance/steps/base-verbs.step.ts
+++ b/tests/acceptance/steps/base-verbs.step.ts
@@ -15,6 +15,8 @@ export type WorldDefinition = {
   userIdentityPostResponse?: Response;
   authorizationResponse?: AuthorizationResponse | OAuthBadRequest;
   tokenResponse?: TokenResponse | OAuthBadRequest;
+  redirectUri?: string;
+  state?: string;
 };
 
 setDefaultTimeout(20_000);
@@ -34,6 +36,8 @@ Before<WorldDefinition>(async function () {
   this.keyId = await getSigningKeyId();
   this.authorizationResponse = undefined;
   this.tokenResponse = undefined;
+  this.redirectUri = undefined;
+  this.state = undefined;
 });
 
 function generateRandomTestUserId() {

--- a/tests/acceptance/steps/utils/auth-api.ts
+++ b/tests/acceptance/steps/utils/auth-api.ts
@@ -13,9 +13,14 @@ export type AuthorizationParameters = {
   state: string;
 };
 
+export type RedirectResponse = {
+  origin: string;
+};
+
 export type AuthorizationResponse = {
   origin: string;
   code: string | null;
+  state: string | null;
 };
 
 export type OAuthBadRequest = {
@@ -57,12 +62,13 @@ export const isAwsError = (response: unknown): response is AwsError => {
   return !!response && typeof response === "object" && "message" in response;
 };
 
-export const isAuthorizationResponse = (response: unknown): response is AuthorizationResponse =>
-  !!response && typeof response === "object" && "origin" in response && "code" in response;
+export const isRedirectResponse = (response: unknown): response is RedirectResponse =>
+  !!response && typeof response === "object" && "origin" in response;
 
-export const authorize = async (
-  parameters: AuthorizationParameters
-): Promise<AuthorizationResponse | OAuthBadRequest> => {
+export const isAuthorizationResponse = (response: unknown): response is AuthorizationResponse =>
+  !!response && typeof response === "object" && "origin" in response && "code" in response && "state" in response;
+
+export const authorize = async (parameters: AuthorizationParameters): Promise<RedirectResponse | OAuthBadRequest> => {
   const publicApi = await getCloudFormationOutput(CloudFormationOutputs.SisPublicApi);
 
   const response = await request(publicApi).get("/authorize").query(parameters).send();
@@ -71,10 +77,9 @@ export const authorize = async (
   }
 
   if (response.statusCode === 302) {
-    const { origin, search } = new URL(response.header["location"]);
+    const { origin } = new URL(response.header["location"]);
     return {
       origin,
-      code: new URLSearchParams(search).get("code"),
     };
   }
 
@@ -111,6 +116,7 @@ export const confirmDetailsSubmission = async (
     return {
       origin,
       code: new URLSearchParams(search).get("code"),
+      state: new URLSearchParams(search).get("state"),
     };
   }
 

--- a/tests/acceptance/steps/utils/auth-api.ts
+++ b/tests/acceptance/steps/utils/auth-api.ts
@@ -15,6 +15,7 @@ export type AuthorizationParameters = {
 
 export type RedirectResponse = {
   origin: string;
+  pathname: string;
 };
 
 export type AuthorizationResponse = {
@@ -68,18 +69,19 @@ export const isRedirectResponse = (response: unknown): response is RedirectRespo
 export const isAuthorizationResponse = (response: unknown): response is AuthorizationResponse =>
   !!response && typeof response === "object" && "origin" in response && "code" in response && "state" in response;
 
-export const authorize = async (parameters: AuthorizationParameters): Promise<RedirectResponse | OAuthBadRequest> => {
+export const authorize = async (parameters: AuthorizationParameters): Promise<RedirectResponse | Error> => {
   const publicApi = await getCloudFormationOutput(CloudFormationOutputs.SisPublicApi);
 
   const response = await request(publicApi).get("/authorize").query(parameters).send();
   if (isAwsError(response.body)) {
-    return { error: "error", error_description: response.body.message };
+    return new Error("error", { cause: response.body.message });
   }
 
   if (response.statusCode === 302) {
-    const { origin } = new URL(response.header["location"]);
+    const { origin, pathname } = new URL(response.header["location"]);
     return {
       origin,
+      pathname,
     };
   }
 

--- a/tests/acceptance/steps/utils/auth-api.ts
+++ b/tests/acceptance/steps/utils/auth-api.ts
@@ -94,3 +94,25 @@ export const token = async (parameters: TokenRequest): Promise<TokenResponse | O
 
   return response.body;
 };
+
+export const confirmDetailsSubmission = async (
+  redirectUri: string,
+  state: string
+): Promise<AuthorizationResponse | OAuthBadRequest> => {
+  const publicApi = await getCloudFormationOutput(CloudFormationOutputs.SisPublicApi);
+
+  const response = await request(publicApi)
+    .post("/confirm-details")
+    .set("content-type", "application/x-www-form-urlencoded")
+    .send({ redirectUri, state });
+
+  if (response.statusCode === 302) {
+    const { origin, search } = new URL(response.header["location"]);
+    return {
+      origin,
+      code: new URLSearchParams(search).get("code"),
+    };
+  }
+
+  return { error: "error", error_description: `Expected 302 but got ${response.statusCode}` };
+};


### PR DESCRIPTION
## What

<!-- Describe the changes in detail - the "what"-->
<!-- Include all information the reviewer needs for context -->

This adds some extra steps to the `authorization-workflow.feature` acceptance tests.
- Use of `I` have been replaced with either `the client` or `the user`
- State is now passed in along with the initial redirect URI
- User clicking the continue button is accounted for by sending a POST request (handled in `confirmDetailsSubmission()`)
- `redirectUri` and `state` have been added to the WorldDefinition to allow usage between steps

## Why

<!-- Describe the reason these changes were made - the "why" -->
<!-- Include all information the reviewer needs for context -->

The feature tests didn't provide a robust test to give confidence in the new OAuth flow. The changes should better mimic how a real user will navigate the OAuth flow 

## additional sections as needed

<!-- if you feel the PR description warrants additional detail, add extra sections, for example notes on how to test (if required) -->

## Related PRs

<!-- Include links to any PRs, in this repo or others, related to this change, for example a related configuration change (delete this section if not applicable) -->
