### PR TITLE
SPT-1969: Don't deploy phase 3 resources to prod yet

### DIFF
--- a/infrastructure/identity-reuse-service/template.yaml
+++ b/infrastructure/identity-reuse-service/template.yaml
@@ -517,6 +517,7 @@ Resources:
 
   AuthorizationFunctionLogGroup:
     Type: AWS::Logs::LogGroup
+    Condition: IsNotProduction
     Properties:
       LogGroupName: !Sub "/aws/lambda/${AWS::StackName}-AuthorizationFunction"
       RetentionInDays: 30
@@ -697,6 +698,7 @@ Resources:
 
   TokenFunctionLogGroup:
     Type: AWS::Logs::LogGroup
+    Condition: IsNotProduction
     Properties:
       LogGroupName: !Sub "/aws/lambda/${AWS::StackName}-TokenFunction"
       RetentionInDays: 30
@@ -750,6 +752,7 @@ Resources:
   ################################
   UserIdentityHandlerFunction:
     Type: AWS::Serverless::Function
+    Condition: IsNotProduction
     Properties:
       FunctionName: !Sub "${AWS::StackName}-UserIdentityHandlerFunction"
       Description: "A lambda function that queues SIS data for processing"
@@ -806,6 +809,7 @@ Resources:
 
   UserIdentityHandlerFunctionRole:
     Type: AWS::IAM::Role
+    Condition: IsNotProduction
     Properties:
       RoleName: !Sub "${AWS::StackName}-UserIdentityHandlerFunctionRole"
       Description: !Sub "The role assumed by ${AWS::StackName}-UserIdentityHandlerFunction"
@@ -839,6 +843,7 @@ Resources:
 
   UserIdentityHandlerFunctionPolicy:
     Type: AWS::IAM::Policy
+    Condition: IsNotProduction
     Properties:
       PolicyName: !Sub "${AWS::StackName}-UserIdentityHandlerFunctionPolicy"
       PolicyDocument:
@@ -863,6 +868,7 @@ Resources:
 
   UserIdentityHandlerRestApiRole:
     Type: AWS::IAM::Role
+    Condition: IsNotProduction
     Properties:
       RoleName: !Sub "${AWS::StackName}-UserIdentityHandlerRestApiRole"
       Description: !Sub "Update User identity Function related permissions for the ${AWS::StackName}-RestApi Gateway IAM role"
@@ -889,6 +895,7 @@ Resources:
 
   UserIdentityHandlerRestApiPolicy:
     Type: AWS::IAM::Policy
+    Condition: IsNotProduction
     Properties:
       PolicyName: !Sub "${AWS::StackName}-UserIdentityHandlerRestApiPolicy"
       PolicyDocument:
@@ -904,6 +911,7 @@ Resources:
 
   UserIdentityHandlerFunctionLogGroup:
     Type: AWS::Logs::LogGroup
+    Condition: IsNotProduction
     Properties:
       LogGroupName: !Sub "/aws/lambda/${UserIdentityHandlerFunction}"
       RetentionInDays: 30


### PR DESCRIPTION
## What

<!-- Describe the changes in detail - the "what"-->
<!-- Include all information the reviewer needs for context -->

Don't deploy the `UserIdentityHandlerFunction` and various log groups to integration of prod.

## Why

<!-- Describe the reason these changes were made - the "why" -->
<!-- Include all information the reviewer needs for context -->

The UserIdentityHandlerFunction is not being used in production yet and we want to only deploy it up to staging whilst we are still building the OAuth server. The same is true for various log groups associated with the build of the OAuth server.
