### PR TITLE
SPT-2005: Update stacks to use TxMA queue from shared stack

### DIFF
--- a/.github/aws-oidc-provider/gha-aws-oidc-provider-template.yaml
+++ b/.github/aws-oidc-provider/gha-aws-oidc-provider-template.yaml
@@ -88,7 +88,20 @@ Resources:
                   - s3:PutEncryptionConfiguration
                   - s3:ListBucket
                   - s3:DeleteObject
-
+              - Sid: "ConsumeServerlessApplicationRepository"
+                Effect: "Allow"
+                Action:
+                  - "serverlessrepo:GetCloudFormationTemplate"
+                  - "serverlessrepo:CreateCloudFormationTemplate"
+                Resource:
+                  - !Sub "arn:${AWS::Partition}:serverlessrepo:${AWS::Region}:*:applications/*"
+              - Effect: "Allow"
+                Action:
+                  - "s3:GetObject"
+                  - "s3:GetObjectVersion"
+                Resource:
+                   - !Sub "arn:${AWS::Partition}:s3:::*"
+                   - !Sub "arn:${AWS::Partition}:s3:::*/*"
               - Effect: Allow
                 Resource: arn:aws:s3:::github-actions-deployment*
                 Action:
@@ -119,6 +132,8 @@ Resources:
                   - !Sub arn:aws:cloudformation:${AWS::Region}:aws:transform/*
                 Action:
                   - cloudformation:DeleteStack
+                  - cloudformation:CreateStack
+                  - cloudformation:UpdateStack
                   - cloudformation:GetTemplate
                   - cloudformation:CreateChangeSet
                   - cloudformation:ExecuteChangeSet
@@ -254,6 +269,7 @@ Resources:
                   - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/state-machine/*
                   - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/states/*
                   - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/apigateway/*
+                  - !Sub arn:aws:logs:${AWS::Region}:885513274347:destination:*
                 Action:
                   - logs:PutSubscriptionFilter
                   - logs:CreateLogGroup

--- a/.github/workflows/deploy-to-aws.yml
+++ b/.github/workflows/deploy-to-aws.yml
@@ -14,6 +14,12 @@ on:
         default: preview-pr-${{ github.event.pull_request.number }}-oauth"
         required: false
         type: string
+      capabilities:
+        description: >
+          The capability list passed to CloudFormation (normally, the default is sufficient)
+        default: 'CAPABILITY_NAMED_IAM'
+        required: false
+        type: string
       environment-name:
         description: >
           The name of the environment. If this is not provided it's taken from the branch name.
@@ -110,12 +116,10 @@ jobs:
         env:
           STACK_NAME: ${{ inputs.stack-name }}
           ENVIRONMENT_NAME: ${{ inputs.environment-name }}
-          OAUTH_STACK_NAME: ${{ inputs.oauth-stack-name }}
         run: |
           echo "ENVIRONMENT_NAME=${ENVIRONMENT_NAME}" >> "$GITHUB_ENV"
           echo "STACK_NAME=${STACK_NAME}" >> "$GITHUB_ENV"
           echo "S3_PREFIX=${STACK_NAME}" >> "$GITHUB_ENV"
-          echo "OAUTH_STACK_NAME=${OAUTH_STACK_NAME}" >> "$GITHUB_ENV"
 
       - name: Delete failed stack
         uses: govuk-one-login/github-actions/sam/delete-stacks@0eb1972f8c0d539b3ff4c24d78b3dba917343e7c
@@ -124,24 +128,11 @@ jobs:
           stack-names: ${{ env.STACK_NAME }}
           aws-region: ${{ env.AWS_REGION }}
 
-      #      N.B. Comment out until we've solved the circular dependency
-      #      - name: Deploy OAuth Stack
-      #        timeout-minutes: 15
-      #        run: |
-      #          echo "$OAUTH_STACK_NAME"
-      #          sam deploy \
-      #          --stack-name "$OAUTH_STACK_NAME"
-      #          --region "$AWS_REGION"  \
-      #          --no-confirm-changeset \
-      #          --no-fail-on-empty-changeset \
-      #          --capabilities CAPABILITY_NAMED_IAM,CAPABILITY_AUTO_EXPAND \
-      #          --tags DeploymentSource="GitHub Actions" StackType=Preview \
-      #          --parameter-overrides Environment="dev" SisStackName=preview-main
-
       - name: Deploy SAM Application
         timeout-minutes: 15
         env:
           S3_BUCKET: ${{ secrets.aws-s3-bucket }}
+          OAUTH_STACK_NAME: ${{ inputs.oauth-stack-name }}
         run: |
           echo "$STACK_NAME"
           echo "$S3_BUCKET"
@@ -152,9 +143,9 @@ jobs:
             --s3-bucket "$S3_BUCKET" \
             --no-confirm-changeset \
             --no-fail-on-empty-changeset \
-            --capabilities CAPABILITY_NAMED_IAM \
+            --capabilities ${{ inputs.capabilities }} \
             --tags DeploymentSource="GitHub Actions" StackType=Preview \
-            --parameter-overrides Environment="dev" OauthInternalStackName=preview-main-oauth
+            --parameter-overrides Environment=dev SharedStackName=reuse-identity-shared "OauthInternalStackName=${OAUTH_STACK_NAME}"
 
       - name: Report deployment
         run: echo "Deployed stack \`$STACK_NAME\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -79,7 +79,7 @@ jobs:
       contents: read
       packages: read
 
-  preview-main:
+  preview-oauth:
     uses: ./.github/workflows/deploy-to-aws.yml
     needs:
       - build
@@ -88,6 +88,24 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    with:
+      stack-name: preview-main-oauth
+      artifact-name: built-oauth-code
+      capabilities: 'CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND'
+    secrets:
+      aws-role-arn: ${{ secrets.GHA_AWS_ROLE_ARN }}
+      aws-s3-bucket: ${{ secrets.GHA_SAM_DEPLOYMENT_BUCKET }}
+
+  preview-main:
+    uses: ./.github/workflows/deploy-to-aws.yml
+    needs:
+      - preview-oauth
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      stack-name: preview-main
+      oauth-stack-name: preview-main-oauth
     secrets:
       aws-role-arn: ${{ secrets.GHA_AWS_ROLE_ARN }}
       aws-s3-bucket: ${{ secrets.GHA_SAM_DEPLOYMENT_BUCKET }}

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -15,6 +15,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       artifact-name: built-code
+      oauth-artifact-name: built-oauth-code
       aws-region: eu-west-2
     permissions:
       contents: read
@@ -46,7 +47,7 @@ jobs:
       contents: read
       packages: read
 
-  preview:
+  preview-oauth:
     if: ${{ !github.event.pull_request.draft && contains( github.event.pull_request.labels.*.name, 'deploy')}}
     uses: ./.github/workflows/deploy-to-aws.yml
     needs:
@@ -55,7 +56,24 @@ jobs:
       id-token: write
       contents: read
     with:
+      stack-name: preview-oauth-pr-${{ github.event.pull_request.number }}
+      artifact-name: built-oauth-code
+      capabilities: 'CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND'
+    secrets:
+      aws-role-arn: ${{ secrets.GHA_AWS_ROLE_ARN }}
+      aws-s3-bucket: ${{ secrets.GHA_SAM_DEPLOYMENT_BUCKET }}
+
+  preview:
+    if: ${{ !github.event.pull_request.draft && contains( github.event.pull_request.labels.*.name, 'deploy')}}
+    uses: ./.github/workflows/deploy-to-aws.yml
+    needs:
+      - preview-oauth
+    permissions:
+      id-token: write
+      contents: read
+    with:
       stack-name: preview-pr-${{ github.event.pull_request.number }}
+      oauth-stack-name: preview-oauth-pr-${{ github.event.pull_request.number }}
     secrets:
       aws-role-arn: ${{ secrets.GHA_AWS_ROLE_ARN }}
       aws-s3-bucket: ${{ secrets.GHA_SAM_DEPLOYMENT_BUCKET }}

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,7 +133,7 @@
         "filename": ".github/aws-oidc-provider/gha-aws-oidc-provider-template.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
-        "line_number": 196,
+        "line_number": 211,
         "is_secret": false
       }
     ],
@@ -196,5 +196,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-08T08:41:20Z"
+  "generated_at": "2026-07-09T14:29:15Z"
 }

--- a/deploy-to-dev.sh
+++ b/deploy-to-dev.sh
@@ -14,9 +14,8 @@ Usage:
     -e      --environment       Environment that the stack is being deployed to. (default = 'local')
     -o      --oauth-deploy      Deploy the oauth-internal stack (optional)
     -n      --no-sis-deploy     Do not deploy the identity-reuse-service stack (optional)
-    -m      --sis-stack-name    The name of an existing identity-reuse-service stack that the oauth-internal can point
-                                at for audit infrastructure and only relevant if not deploying a fresh
-                                identity-reuse-service stack. (optional)
+    -m      --shared-stack-name The name of an existing identity-reuse-shared stack that the oauth-internal can point
+                                at for audit infrastructure. (optional)
     -f      --force-build       Forces a build instead of using the build cache. (optional)
     -y      --no-confirm        Don't require changes to be confirmed when deploying
     -r      --resolve-s3        Force use default SAM managed bucket when samconfig.toml is present.
@@ -92,7 +91,7 @@ deploy_or_destroy() {
 
 DEPLOY_SIS=true
 DEPLOY_OAUTH=false
-SIS_STACK_NAME="preview-main"
+SHARED_STACK_NAME="identity-reuse-shared"
 RESOLVE_S3=false
 CONFIRM_CHANGES=true
 BUILD_CACHE="--cached"
@@ -120,9 +119,9 @@ while [[ -n "${1}" ]]; do
     -n | --no-sis-deploy)
       DEPLOY_SIS=false
       ;;
-    -m | --sis-stack-name)
+    -m | --shared-stack-name)
       shift
-      SIS_STACK_NAME="${1}"
+      SHARED_STACK_NAME="${1}"
       ;;
     -r | --resolve-s3)
       RESOLVE_S3=true
@@ -184,13 +183,14 @@ fi
 export AWS_DEFAULT_REGION=eu-west-2
 echo "Environment: ${ENVIRONMENT}"
 echo "Profile:     ${AWS_PROFILE}"
-$DEPLOY_SIS && echo "Deploy identity-reuse-service to stack ${SIS_STACK_NAME}"
-$DEPLOY_OAUTH && echo "Deploy oauth-internal to stack ${OAUTH_STACK_NAME}, pointing at identity-reuse-service stack ${SIS_STACK_NAME}"
+$DEPLOY_SIS && echo "Deploy identity-reuse-service to stack ${SIS_STACK_NAME}, pointing at shared stack ${SHARED_STACK_NAME}"
+$DEPLOY_OAUTH && echo "Deploy oauth-internal to stack ${OAUTH_STACK_NAME}, pointing at shared stack ${SHARED_STACK_NAME}"
 echo
 
-if $DEPLOY_SIS; then
-  deploy_or_destroy "identity-reuse-service" "${SIS_STACK_NAME}" "OauthInternalStackName=${OAUTH_STACK_NAME}"
+if "${DEPLOY_OAUTH}"; then
+  deploy_or_destroy "oauth-internal" "${OAUTH_STACK_NAME}" "SharedStackName=${SHARED_STACK_NAME}"
 fi
-if $DEPLOY_OAUTH; then
-  deploy_or_destroy "oauth-internal" "${OAUTH_STACK_NAME}" "SisStackName=${SIS_STACK_NAME}"
+
+if "${DEPLOY_SIS}"; then
+  deploy_or_destroy "identity-reuse-service" "${SIS_STACK_NAME}" "OauthInternalStackName=${OAUTH_STACK_NAME}" "SharedStackName=${SHARED_STACK_NAME}"
 fi

--- a/infrastructure/identity-reuse-service/template.yaml
+++ b/infrastructure/identity-reuse-service/template.yaml
@@ -381,7 +381,8 @@ Resources:
           ENVIRONMENT: !If [IsDev, "dev", !Ref Environment]
           APP_CONFIG_NAME: !Ref ApplicationConfigName
           APP_CONFIG_APPLICATION: !Ref ApplicationName
-          SQS_AUDIT_EVENT_QUEUE_URL: !Ref AuditEventQueue
+          SQS_AUDIT_EVENT_QUEUE_URL:
+            Fn::ImportValue: !Sub ${SharedStackName}-AuditEventQueueUrl
           COMPONENT_ID: !Ref ComponentId
           DOMAIN_NAME: !Ref ReuseIdentityCustomDomain
           OAUTH_INTERNAL_API_URL:
@@ -468,7 +469,8 @@ Resources:
           - Effect: Allow
             Action:
               - sqs:SendMessage
-            Resource: !GetAtt AuditEventQueue.Arn
+            Resource:
+              Fn::ImportValue: !Sub ${SharedStackName}-AuditEventQueueArn
       Roles:
         - !Ref GetAuthorizeHandlerRole
 
@@ -565,7 +567,8 @@ Resources:
           ENVIRONMENT: !If [IsDev, "dev", !Ref Environment]
           APP_CONFIG_NAME: !Ref ApplicationConfigName
           APP_CONFIG_APPLICATION: !Ref ApplicationName
-          SQS_AUDIT_EVENT_QUEUE_URL: !Ref AuditEventQueue
+          SQS_AUDIT_EVENT_QUEUE_URL:
+            Fn::ImportValue: !Sub ${SharedStackName}-AuditEventQueueUrl
           COMPONENT_ID: !Ref ComponentId
       CodeSigningConfigArn: !If
         - UseCodeSigning
@@ -649,7 +652,8 @@ Resources:
           - Effect: Allow
             Action:
               - sqs:SendMessage
-            Resource: !GetAtt AuditEventQueue.Arn
+            Resource:
+              Fn::ImportValue: !Sub ${SharedStackName}-AuditEventQueueArn
       Roles:
         - !Ref PostTokenHandlerRole
 
@@ -778,7 +782,8 @@ Resources:
           ENVIRONMENT: !If [IsDev, "dev", !Ref Environment]
           APP_CONFIG_NAME: !Ref ApplicationConfigName
           APP_CONFIG_APPLICATION: !Ref ApplicationName
-          SQS_AUDIT_EVENT_QUEUE_URL: !Ref AuditEventQueue
+          SQS_AUDIT_EVENT_QUEUE_URL:
+            Fn::ImportValue: !Sub ${SharedStackName}-AuditEventQueueUrl
           COMPONENT_ID: !Ref ComponentId
       CodeSigningConfigArn: !If
         - UseCodeSigning
@@ -862,7 +867,8 @@ Resources:
           - Effect: Allow
             Action:
               - sqs:SendMessage
-            Resource: !GetAtt AuditEventQueue.Arn
+            Resource:
+              Fn::ImportValue: !Sub ${SharedStackName}-AuditEventQueueArn
       Roles:
         - !Ref GetUserIdentityHandlerRole
 
@@ -1905,7 +1911,8 @@ Resources:
           ENVIRONMENT: !If [IsDev, "dev", !Ref Environment]
           APP_CONFIG_NAME: !Ref ApplicationConfigName
           APP_CONFIG_APPLICATION: !Ref ApplicationName
-          SQS_AUDIT_EVENT_QUEUE_URL: !Ref AuditEventQueue
+          SQS_AUDIT_EVENT_QUEUE_URL:
+            Fn::ImportValue: !Sub ${SharedStackName}-AuditEventQueueUrl
           COMPONENT_ID: !Ref ComponentId
       CodeSigningConfigArn: !If
         - UseCodeSigning
@@ -1988,6 +1995,12 @@ Resources:
             Action:
               - sqs:SendMessage
             Resource: !GetAtt AuditEventQueue.Arn
+          - Effect: Allow
+            Action:
+              - sqs:SendMessage
+            Resource:
+              Fn::ImportValue: !Sub ${SharedStackName}-AuditEventQueueArn
+
       Roles:
         - !Ref UserIdentityFunctionRole
 
@@ -2239,7 +2252,8 @@ Resources:
           ENVIRONMENT: !If [IsDev, "dev", !Ref Environment]
           APP_CONFIG_NAME: !Ref ApplicationConfigName
           APP_CONFIG_APPLICATION: !Ref ApplicationName
-          SQS_AUDIT_EVENT_QUEUE_URL: !Ref AuditEventQueue
+          SQS_AUDIT_EVENT_QUEUE_URL:
+            Fn::ImportValue: !Sub ${SharedStackName}-AuditEventQueueUrl
           COMPONENT_ID: !Ref ComponentId
       Tags:
         Product: !Ref ProductTagValue
@@ -2316,6 +2330,11 @@ Resources:
             Action:
               - sqs:SendMessage
             Resource: !GetAtt AuditEventQueue.Arn
+          - Effect: Allow
+            Action:
+              - sqs:SendMessage
+            Resource:
+              Fn::ImportValue: !Sub ${SharedStackName}-AuditEventQueueArn
           - Effect: Allow
             Action:
               - kms:Decrypt

--- a/infrastructure/oauth-internal/template.yaml
+++ b/infrastructure/oauth-internal/template.yaml
@@ -71,11 +71,6 @@ Parameters:
     Type: String
     Default: none
 
-  SisStackName:
-    Description: The name of the main SIS stack containing audit queue infrastructure
-    Type: String
-    Default: sis-main
-
   OAuthClientId:
     Description: "The client ID used by the main OAuth client"
     Type: String
@@ -90,6 +85,11 @@ Parameters:
     Description: Value for the Product Tag
     Type: String
     Default: GOV.UK One Login
+
+  SharedStackName:
+    Description: The name of the Identity Reuse Service Shared Stack
+    Type: String
+    Default: reuse-identity-shared
 
   SourceTagValue:
     Description: Value for the Source Tag
@@ -168,7 +168,7 @@ Resources:
         SemanticVersion: 0.5.0
       Parameters:
         AuditEventNamePrefix: !Ref AuditEventNamePrefix
-        AuditTxmaStackName: !Ref SisStackName # TXMA infrastructure lives in the identity-reuse-service stack
+        AuditTxmaStackName: !Ref SharedStackName # TXMA infrastructure lives in the reuse-identity-shared stack
         CSLSDestinationArn: !Ref CSLSSubscriptionEndpointArn
         CriIdentifier: !Ref MainCloudWatchMetricNamespace # Used for the metrics namespace and metrics service names only
         CriAudience: !FindInMap [ EnvironmentMap, !Ref Environment, SISAudience ] # Sets the Audience value for the SIS OAuth 2.0 server


### PR DESCRIPTION
## What

Update the OAuth internal and main SIS stack stacks to include a new parameter (`SharedStackName`) that contains the name of the shared stack to use for the deployment.

Use the exports from the specified shared stack to define the TxMA audit queues the functions use and the appropriate permissions.

## Why

This removes a circular dependency between the two stacks where the OAuth stack needs SIS for the TxMA queues, but SIS needs the OAuth stack for API Gateway URL.


## Related PRs

https://github.com/govuk-one-login/ipv-identity-reuse-service-config/pull/159
https://github.com/govuk-one-login/ipv-identity-reuse-service-config/pull/163
