### PR TITLE
SPT-1973: Pass state to the authorization endpoint

### DIFF
--- a/src/handlers/get-callback-handler/get-callback-handler.ts
+++ b/src/handlers/get-callback-handler/get-callback-handler.ts
@@ -26,6 +26,7 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
 
   url.searchParams.append("client_id", queryParameters.client_id);
   url.searchParams.append("redirect_uri", queryParameters.redirect_uri);
+  url.searchParams.append("state", queryParameters.state);
   url.searchParams.append("response_type", "code");
 
   try {

--- a/src/handlers/get-callback-handler/tests/get-callback-handler.test.ts
+++ b/src/handlers/get-callback-handler/tests/get-callback-handler.test.ts
@@ -45,6 +45,28 @@ it("should return a 302 status code and redirect with an auth code and state on 
   });
 });
 
+it("should return a 302 status code and redirect to the SIS error page when /api/authorization API call returns 200 with an empty state object", async () => {
+  const event = createMockAPIGatewayProxyEvent({}, "");
+
+  globalThis.fetch = vitest.fn().mockResolvedValue({
+    status: 200,
+    json: vitest.fn().mockResolvedValue({
+      redirectionURI: "https://api.example.com",
+      authorizationCode: { value: "test-auth-code" },
+      state: {},
+    }),
+  });
+
+  const response = await handler(event);
+  expect(response).toStrictEqual({
+    statusCode: 302,
+    body: "",
+    headers: {
+      Location: "https://test-domain/error/unrecoverable",
+    },
+  });
+});
+
 it("should return a 302 status code and redirect with an access_denied error and state when /api/authorization API call returns 403", async () => {
   const event = createMockAPIGatewayProxyEvent({}, "");
 


### PR DESCRIPTION
## What
- Pass the `state` in the query parameters to the `/api/authorization` endpoint call
- Add a unit test to cover the scenario where the response from the authorization endpoint includes an empty `state` object

## Why
The ipv-cri-oauth-common's authorization API reads the `state` from the query parameters instead of using the session table: https://github.com/govuk-one-login/ipv-cri-oauth-common/blob/main/lambdas/src/handlers/authorization-handler.ts#L56. When it is missing from the query parameters, the API call returns a blank value for the state in the response, which causes the validation in our code to fail. It still redirects to the callback URL since it returns a 200 response.

## Related PRs
https://github.com/govuk-one-login/ipv-identity-reuse-service/pull/364