### PR TITLE
SPT-1973: Fix error when reading API response

### DIFF
--- a/src/handlers/get-callback-handler/get-callback-handler.ts
+++ b/src/handlers/get-callback-handler/get-callback-handler.ts
@@ -52,12 +52,13 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
 };
 
 const redirectToClient = async (authorizationResponse: Response, domainName: string) => {
-  if (!isValidSuccessResponse(await authorizationResponse.json())) {
+  const authResponseJson = await authorizationResponse.json();
+  if (!isValidSuccessResponse(authResponseJson)) {
     logger.error("Invalid response properties received from authorization endpoint");
     return await redirectToErrorPage(domainName);
   }
 
-  const authorizationData = (await authorizationResponse.json()) as AuthorizationSuccessResponse;
+  const authorizationData = authResponseJson as AuthorizationSuccessResponse;
   const orchestrationRedirectUrl = new URL(decodeURIComponent(authorizationData.redirectionURI));
   orchestrationRedirectUrl.searchParams.append("code", authorizationData.authorizationCode.value);
   orchestrationRedirectUrl.searchParams.append("state", authorizationData.state.value);

--- a/src/handlers/get-callback-handler/tests/get-callback-handler.test.ts
+++ b/src/handlers/get-callback-handler/tests/get-callback-handler.test.ts
@@ -21,6 +21,31 @@ vitest.mock("@aws-lambda-powertools/logger", () => {
   };
 });
 
+it("should only read the response body once and redirect successfully", async () => {
+  const mockJsonMethod = vitest.fn().mockResolvedValue({
+    redirectionURI: "https://api.example.com",
+    authorizationCode: { value: "test-auth-code" },
+    state: { value: "test-state" },
+  });
+
+  globalThis.fetch = vitest.fn().mockResolvedValue({
+    status: 200,
+    json: mockJsonMethod,
+  });
+
+  const event = createMockAPIGatewayProxyEvent({}, "");
+  const response = await handler(event);
+
+  expect(mockJsonMethod).toHaveBeenCalledTimes(1);
+  expect(response).toStrictEqual({
+    statusCode: 302,
+    body: "",
+    headers: {
+      Location: "https://api.example.com/?code=test-auth-code&state=test-state",
+    },
+  });
+});
+
 it("should return a 302 status code and redirect with an auth code and state on a successful request", async () => {
   const event = createMockAPIGatewayProxyEvent({}, "");
   const token = getCookieValues(event)!.get("identity_reuse_service_session");


### PR DESCRIPTION
## What
Change the logic to read the `/api/authorization` endpoint's response body once, instead of re-reading it for both the Type Guard function and accessing the properties for the redirect.

## Why
To resolve the error caused by consuming the data stream multiple times.

## Related PRs
https://github.com/govuk-one-login/ipv-identity-reuse-service/pull/364
https://github.com/govuk-one-login/ipv-identity-reuse-service/pull/378