### PR TITLE
SPT-1969: Ensure API Gateway role allows invoke on Lambda alias

### DIFF
--- a/infrastructure/identity-reuse-service/template.yaml
+++ b/infrastructure/identity-reuse-service/template.yaml
@@ -511,7 +511,7 @@ Resources:
             Action:
               - "lambda:InvokeFunction"
             Resource:
-              - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${AWS::StackName}-GetAuthorizeHandler:*"
+              - !Sub "${GetAuthorizeHandler.Arn}:*"
       Roles:
         - !Ref GetAuthorizeHandlerRestApiRole
 
@@ -692,7 +692,7 @@ Resources:
             Action:
               - "lambda:InvokeFunction"
             Resource:
-              - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${AWS::StackName}-PostTokenHandler:*"
+              - !Sub "${PostTokenHandler.Arn}:*"
       Roles:
         - !Ref PostTokenHandlerRestApiRole
 
@@ -905,7 +905,7 @@ Resources:
             Action:
               - "lambda:InvokeFunction"
             Resource:
-              - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${AWS::StackName}-GetUserIdentityHandler:*"
+              - !Sub "${GetUserIdentityHandler.Arn}:*"
       Roles:
         - !Ref GetUserIdentityHandlerRestApiRole
 
@@ -1247,7 +1247,7 @@ Resources:
             Action:
               - "lambda:InvokeFunction"
             Resource:
-              - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${AWS::StackName}-GetConfirmDetailsHandler:*"
+              - !Sub "${GetConfirmDetailsHandler.Arn}:*"
       Roles:
         - !Ref GetConfirmDetailsHandlerRestApiRole
 
@@ -1473,7 +1473,7 @@ Resources:
             Action:
               - "lambda:InvokeFunction"
             Resource:
-              - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${AWS::StackName}-GetUnrecoverableErrorHandler:*"
+              - !Sub "${GetUnrecoverableErrorHandler.Arn}:*"
       Roles:
         - !Ref GetUnrecoverableErrorHandlerRestApiRole
 
@@ -1596,7 +1596,7 @@ Resources:
             Action:
               - "lambda:InvokeFunction"
             Resource:
-              - !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${AWS::StackName}-GetCallbackHandler:*"
+              - !Sub "${GetCallbackHandler.Arn}:*"
       Roles:
         - !Ref GetCallbackHandlerRestApiRole
 

--- a/infrastructure/identity-reuse-service/template.yaml
+++ b/infrastructure/identity-reuse-service/template.yaml
@@ -1352,7 +1352,7 @@ Resources:
             Action:
               - "lambda:InvokeFunction"
             Resource:
-              - !GetAtt PostConfirmDetailsHandler.Arn
+              - !Sub "${PostConfirmDetailsHandler.Arn}:*"
       Roles:
         - !Ref PostConfirmDetailsHandlerRestApiRole
 


### PR DESCRIPTION
## What

<!-- Describe the changes in detail - the "what"-->
<!-- Include all information the reviewer needs for context -->

* Fix the `POST /confirm-details` endpoint which did not have permission to call the `PostConfirmDetailsHandler` by Lambda alias
* Update the other `*HandlerRestApiPolicy`s to reference the `.arn` property rather than handcrafting ARNs (on non-prod resources only, prod will be done separately)

## Why

<!-- Describe the reason these changes were made - the "why" -->
<!-- Include all information the reviewer needs for context -->

[A previous PR ](https://github.com/govuk-one-login/ipv-identity-reuse-service/pull/363) renamed some of the lambda functions. It also created a new role for the `POST /confirm-details` lambda to call the `PostConfirmDetailsHandler`. Previously it had shared a role with the `GET /confirm-details` endpoint which allowed both to call `PostConfirmDetailsHandler` AND `GetConfirmDetailsHandler`. Splitting these into individual roles is a more secure way of doing this. When the new role was created it used the ARN attribute (which is better) but forgot to include the alias.

## Testing

<!-- if you feel the PR description warrants additional detail, add extra sections, for example notes on how to test (if required) -->

The acceptance tests don't currently test this endpoint (they will soon). You can test manually by going to the orch stub and copying the `/authorize` call onto the domain for this PR.

https://preview-pr-380.reuse-identity.dev.account.gov.uk/

## Related PRs

<!-- Include links to any PRs, in this repo or others, related to this change, for example a related configuration change (delete this section if not applicable) -->

* https://github.com/govuk-one-login/ipv-identity-reuse-service/pull/363
