### PR TITLE
BAU: Enforce gitlint in pre-merge checks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,3 +13,7 @@ quote_type = double
 
 [*.md]
 trim_trailing_whitespace = false
+
+[COMMIT_EDITMSG]
+trim_trailing_whitespace = true
+max_line_length = 72

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -31,3 +31,31 @@ jobs:
           pull-repository: true
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  run-gitlint:
+    if: ${{ !github.event.pull_request.draft }}
+    name: Run Gitlint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Calculate fetch depth
+        id: calculate-fetch-depth
+        env:
+          NUMBER_OF_PR_COMMITS: ${{ github.event.pull_request.commits }}
+        run: |
+          echo "Number of PR ${NUMBER_OF_PR_COMMITS}"
+          echo "FETCH_DEPTH=$(($NUMBER_OF_PR_COMMITS + 1))" >> "${GITHUB_OUTPUT}"
+
+      - name: Pull repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: ${{ steps.calculate-fetch-depth.outputs.FETCH_DEPTH }}
+
+      - name: Install gitlint
+        shell: bash
+        run: |
+          python -m pip install gitlint==0.19.1
+
+      - name: Run gitlint
+        shell: bash
+        run: |
+          gitlint --commits "${{ github.event.pull_request.base.sha }}..HEAD" --fail-without-commits --ignore-stdin


### PR DESCRIPTION
## What

- Add a step to the `pre-commit` workflow that explictly runs gitlint against all commits on the PR. 
- Update `.editorconfig` to help developers who use commit message editors, that obey `.editorconfig`, meet line length and trailing whitespace requirements.

## Why

The existing pre-commit workflow doesn't run the normal pre-commit hook when not run in the post-merge context, so has no message to validate. We have this step in our other repositories but was missed from this one.
