### PR TITLE
SPT-2005: Required permissions and post-merge tweaks

### DIFF
--- a/.github/aws-oidc-provider/gha-aws-oidc-provider-template.yaml
+++ b/.github/aws-oidc-provider/gha-aws-oidc-provider-template.yaml
@@ -45,7 +45,10 @@ Resources:
                 Resource: "*"
                 Action:
                   - iam:GetRole
+                  - iam:TagPolicy
+                  - iam:UntagPolicy
                   - iam:TagRole
+                  - iam:UntagRole
                   - iam:PassRole
                   - iam:CreateRole
                   - iam:DeleteRole
@@ -203,6 +206,7 @@ Resources:
                   - lambda:UpdateEventSourceMapping
                   - lambda:UpdateFunctionConfiguration
                   - lambda:TagResource
+                  - lambda:UntagResource
                   - lambda:GetFunctionConfiguration
 
               - Effect: Allow
@@ -275,6 +279,7 @@ Resources:
                   - logs:CreateLogGroup
                   - logs:ListTagsForResource
                   - logs:TagResource
+                  - logs:UntagResource
 
               - Effect: Allow
                 Resource:

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -90,6 +90,7 @@ jobs:
       contents: read
     with:
       stack-name: preview-main-oauth
+      oauth-stack-name: preview-main-oauth
       artifact-name: built-oauth-code
       capabilities: 'CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND'
     secrets:

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,7 +133,7 @@
         "filename": ".github/aws-oidc-provider/gha-aws-oidc-provider-template.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
-        "line_number": 211,
+        "line_number": 215,
         "is_secret": false
       }
     ],
@@ -196,5 +196,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-09T14:29:15Z"
+  "generated_at": "2026-07-10T14:07:38Z"
 }


### PR DESCRIPTION
## What

- Add the `oauth-stack-name` parameter to the `preview-oauth` step, this isn't strictly required, but it just looks weird and caused confusion while debugging a failed deploy
- Add required "Untag*" permissions that seem to be needed when deploying the oauth-internal stack post merge.

## Why

The post-merge steps failed following merge of #377, this PR fixes the issues.

## Related PRs

#377 