### PR TITLE
SPT-1969: Rename production lambdas - part 2

### DIFF
--- a/infrastructure/identity-reuse-service/template.yaml
+++ b/infrastructure/identity-reuse-service/template.yaml
@@ -3373,7 +3373,7 @@ Resources:
       QueueName: !Sub "${AWS::StackName}-stub-queue"
       KmsMasterKeyId: !Ref StubQueueKey
 
-  MessageProcessorLambdaTrigger:
+  InboundTxmaQueueMessageHandlerTrigger:
     Type: AWS::Lambda::EventSourceMapping
     Properties:
       BatchSize: 1
@@ -3381,7 +3381,7 @@ Resources:
         - IsDevOrBuild
         - !GetAtt StubQueue.Arn
         - !FindInMap [EnvironmentMap, !Ref Environment, messageQueueArn]
-      FunctionName: !Ref MessageProcessorLambda.Alias
+      FunctionName: !Ref InboundTxmaQueueMessageHandler.Alias
       Enabled: true
 
   AuditEventDeadLetterQueueAlarm:
@@ -3535,14 +3535,14 @@ Resources:
       AlarmDescription: "Errors invoking SIS lambda functions"
       Metrics:
         - Id: m1
-          Label: MessageProcessorLambda Errors
+          Label: InboundTxmaQueueMessageHandler Errors
           MetricStat:
             Metric:
               MetricName: Errors
               Namespace: AWS/Lambda
               Dimensions:
                 - Name: FunctionName
-                  Value: !Ref MessageProcessorLambda
+                  Value: !Ref InboundTxmaQueueMessageHandler
             Period: 60
             Stat: Sum
             Unit: Count

--- a/infrastructure/identity-reuse-service/template.yaml
+++ b/infrastructure/identity-reuse-service/template.yaml
@@ -3548,14 +3548,14 @@ Resources:
             Unit: Count
           ReturnData: false
         - Id: m2
-          Label: UserIdentityFunction Errors
+          Label: PostPhase2UserIdentityHandler Errors
           MetricStat:
             Metric:
               MetricName: Errors
               Namespace: AWS/Lambda
               Dimensions:
                 - Name: FunctionName
-                  Value: !Ref UserIdentityFunction
+                  Value: !Ref PostPhase2UserIdentityHandler
             Period: 60
             Stat: Sum
             Unit: Count

--- a/openAPI/api.yaml
+++ b/openAPI/api.yaml
@@ -58,9 +58,9 @@ paths:
       x-amazon-apigateway-integration:
         httpMethod: POST
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${UserIdentityFunction.Arn}:live/invocations
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${PostPhase2UserIdentityHandler.Arn}:live/invocations
         credentials:
-          Fn::GetAtt: UserIdentityRestApiRole.Arn
+          Fn::GetAtt: PostPhase2UserIdentityHandlerRestApiRole.Arn
         passthroughBehavior: NEVER
         contentHandling: CONVERT_TO_TEXT
         type: AWS_PROXY


### PR DESCRIPTION
## What

<!-- Describe the changes in detail - the "what"-->
<!-- Include all information the reviewer needs for context -->

An earlier PR created some new versions of existing Lambdas with new names https://github.com/govuk-one-login/ipv-identity-reuse-service/pull/382.

This PR switches the API and event source mapping to point to the new versions with new names. The old ones will be deleted in a follow up PR. The three-part process ensures the rename is zero-downtime.

Also updates the alarms to point at the new lambdas, so that that the canary deployments operate on the new lambdas.

## Why

<!-- Describe the reason these changes were made - the "why" -->
<!-- Include all information the reviewer needs for context -->

Names that better describe what the resources do.

## Testing

<!-- if you feel the PR description warrants additional detail, add extra sections, for example notes on how to test (if required) -->


Passing acceptance tests should mean the `UserIdentityFunction` rename is ok.

We test the `MessageProcessorLambda` rename manually:

Use the following message:

```
{
  "user_id": "test-user-id",
  "timestamp": 1783691629,
  "intervention_code": "05"
}
```

Go to SQS -> `preview-pr-384-stub-queue` -> Send and receive messages -> Put above message into message body and send

Go to Lambda -> `preview-pr-384-InboundTxmaQueueMessageHandler` -> Monitor -> check you see an invocation of the lambda

> [!NOTE]
> The invocation will fail because it turns out the  `InboundTxmaQueueMessageHandler` cannot call the EVCS stub, due to the `InboundTxmaQueueMessageHandler` being in a private subnet and the EVCS stub being on the public internet. This has always been an issue, so you will see logs in dev where "invalidating the identity" fails because it cannot call EVCS. We will fix this in future, but we know this works in prod because EVCS is on a private subnet there. I believe the fact that the correct lambda is being called and producing logs shows that the change in this PR is working.

## Related PRs

<!-- Include links to any PRs, in this repo or others, related to this change, for example a related configuration change (delete this section if not applicable) -->

* https://github.com/govuk-one-login/ipv-identity-reuse-service/pull/382