### PR TITLE
SPT-1969: Ensure renamed lambdas point at new TXMA queue

### DIFF
--- a/infrastructure/identity-reuse-service/template.yaml
+++ b/infrastructure/identity-reuse-service/template.yaml
@@ -1968,7 +1968,8 @@ Resources:
           ENVIRONMENT: !If [IsDev, "dev", !Ref Environment]
           APP_CONFIG_NAME: !Ref ApplicationConfigName
           APP_CONFIG_APPLICATION: !Ref ApplicationName
-          SQS_AUDIT_EVENT_QUEUE_URL: !Ref AuditEventQueue
+          SQS_AUDIT_EVENT_QUEUE_URL:
+            Fn::ImportValue: !Sub ${SharedStackName}-AuditEventQueueUrl
           COMPONENT_ID: !Ref ComponentId
       CodeSigningConfigArn: !If
         - UseCodeSigning
@@ -2089,7 +2090,6 @@ Resources:
               - sqs:SendMessage
             Resource:
               Fn::ImportValue: !Sub ${SharedStackName}-AuditEventQueueArn
-
       Roles:
         - !Ref UserIdentityFunctionRole
 
@@ -2114,6 +2114,11 @@ Resources:
             Action:
               - sqs:SendMessage
             Resource: !GetAtt AuditEventQueue.Arn
+          - Effect: Allow
+            Action:
+              - sqs:SendMessage
+            Resource:
+              Fn::ImportValue: !Sub ${SharedStackName}-AuditEventQueueArn
       Roles:
         - !Ref PostPhase2UserIdentityHandlerRole
 
@@ -2506,7 +2511,8 @@ Resources:
           ENVIRONMENT: !If [IsDev, "dev", !Ref Environment]
           APP_CONFIG_NAME: !Ref ApplicationConfigName
           APP_CONFIG_APPLICATION: !Ref ApplicationName
-          SQS_AUDIT_EVENT_QUEUE_URL: !Ref AuditEventQueue
+          SQS_AUDIT_EVENT_QUEUE_URL:
+            Fn::ImportValue: !Sub ${SharedStackName}-AuditEventQueueUrl
           COMPONENT_ID: !Ref ComponentId
       Tags:
         Product: !Ref ProductTagValue
@@ -2660,6 +2666,11 @@ Resources:
             Action:
               - sqs:SendMessage
             Resource: !GetAtt AuditEventQueue.Arn
+          - Effect: Allow
+            Action:
+              - sqs:SendMessage
+            Resource:
+              Fn::ImportValue: !Sub ${SharedStackName}-AuditEventQueueArn
           - Effect: Allow
             Action:
               - kms:Decrypt


### PR DESCRIPTION
## What

<!-- Describe the changes in detail - the "what"-->
<!-- Include all information the reviewer needs for context -->

An earlier PR duplicated some lambdas with a new name - https://github.com/govuk-one-login/ipv-identity-reuse-service/pull/382. At the same time, the original lambdas were switched to use a new Audit queue in a separate PR - https://github.com/govuk-one-login/ipv-identity-reuse-service/pull/377. Due to the copy/paste nature of the original PR, the updated Audit queues are not being used in the new versions of the lambdas. This fixes that.

## Why

<!-- Describe the reason these changes were made - the "why" -->
<!-- Include all information the reviewer needs for context -->

We are moving the TXMA queues into a different stack and we want to make sure the renamed versions of the lambdas use the correct Audit queue.

## Related PRs

<!-- Include links to any PRs, in this repo or others, related to this change, for example a related configuration change (delete this section if not applicable) -->

* https://github.com/govuk-one-login/ipv-identity-reuse-service/pull/382
* https://github.com/govuk-one-login/ipv-identity-reuse-service/pull/377