### PR TITLE
SPT-2005: Correct default SHARED_STACK_NAME in deploy script

### DIFF
--- a/deploy-to-dev.sh
+++ b/deploy-to-dev.sh
@@ -91,7 +91,7 @@ deploy_or_destroy() {
 
 DEPLOY_SIS=true
 DEPLOY_OAUTH=false
-SHARED_STACK_NAME="identity-reuse-shared"
+SHARED_STACK_NAME="reuse-identity-shared"
 RESOLVE_S3=false
 CONFIRM_CHANGES=true
 BUILD_CACHE="--cached"


### PR DESCRIPTION
## What

Correct the default value for `SHARED_STACK_NAME` to `reuse-identity-shared` in the `deploy-to-dev.sh`.

## Why

Developers stack are failing to deploy due to the `identity-reuse-shared` stack being non-existent.

This error was introduced in an earlier PR.

## Related PRs

#383 
#377 