### PR TITLE
SPT-2019: Harden Audit Queue Permissions

### DIFF
--- a/infrastructure/identity-reuse-service/template.yaml
+++ b/infrastructure/identity-reuse-service/template.yaml
@@ -2019,6 +2019,7 @@ Resources:
         - arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess
         - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
         - Fn::ImportValue: !Sub "${AppConfigStackName}-AppConfigClientPolicyArn"
+        - Fn::ImportValue: !Sub "${SharedStackName}-AuditEventQueueSendMessagePolicy"
       Tags:
         - Key: Product
           Value: !Ref ProductTagValue
@@ -2052,6 +2053,7 @@ Resources:
         - arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess
         - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
         - Fn::ImportValue: !Sub "${AppConfigStackName}-AppConfigClientPolicyArn"
+        - Fn::ImportValue: !Sub "${SharedStackName}-AuditEventQueueSendMessagePolicy"
       Tags:
         - Key: Product
           Value: !Ref ProductTagValue
@@ -2085,11 +2087,6 @@ Resources:
             Action:
               - sqs:SendMessage
             Resource: !GetAtt AuditEventQueue.Arn
-          - Effect: Allow
-            Action:
-              - sqs:SendMessage
-            Resource:
-              Fn::ImportValue: !Sub ${SharedStackName}-AuditEventQueueArn
       Roles:
         - !Ref UserIdentityFunctionRole
 
@@ -2114,11 +2111,6 @@ Resources:
             Action:
               - sqs:SendMessage
             Resource: !GetAtt AuditEventQueue.Arn
-          - Effect: Allow
-            Action:
-              - sqs:SendMessage
-            Resource:
-              Fn::ImportValue: !Sub ${SharedStackName}-AuditEventQueueArn
       Roles:
         - !Ref PostPhase2UserIdentityHandlerRole
 
@@ -2555,6 +2547,7 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
         - Fn::ImportValue: !Sub "${AppConfigStackName}-AppConfigClientPolicyArn"
+        - Fn::ImportValue: !Sub "${SharedStackName}-AuditEventQueueSendMessagePolicy"
       Tags:
         - Key: Product
           Value: !Ref ProductTagValue
@@ -2587,6 +2580,7 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
         - Fn::ImportValue: !Sub "${AppConfigStackName}-AppConfigClientPolicyArn"
+        - Fn::ImportValue: !Sub "${SharedStackName}-AuditEventQueueSendMessagePolicy"
       Tags:
         - Key: Product
           Value: !Ref ProductTagValue
@@ -2621,11 +2615,6 @@ Resources:
             Action:
               - sqs:SendMessage
             Resource: !GetAtt AuditEventQueue.Arn
-          - Effect: Allow
-            Action:
-              - sqs:SendMessage
-            Resource:
-              Fn::ImportValue: !Sub ${SharedStackName}-AuditEventQueueArn
           - Effect: Allow
             Action:
               - kms:Decrypt
@@ -2666,11 +2655,6 @@ Resources:
             Action:
               - sqs:SendMessage
             Resource: !GetAtt AuditEventQueue.Arn
-          - Effect: Allow
-            Action:
-              - sqs:SendMessage
-            Resource:
-              Fn::ImportValue: !Sub ${SharedStackName}-AuditEventQueueArn
           - Effect: Allow
             Action:
               - kms:Decrypt


### PR DESCRIPTION
## What

<!-- Describe the changes in detail - the "what"-->
<!-- Include all information the reviewer needs for context -->

Refactors the `sqs:SendMessage` policy for lambdas relying on sending messages to the Shared Stack's `AuditEventQueue`
The new policy is imported to the lambda role's `ManagedPolicies` property, with the permission in the lambda policy being deleted

## Why

<!-- Describe the reason these changes were made - the "why" -->
<!-- Include all information the reviewer needs for context -->

There was lots of duplication for setting this policy, so it's been refactored to use a now exported policy (which grants `sqs:SendMessage` to the same queue) rather than repeatedly defining that policy in this template. 

## additional sections as needed

<!-- if you feel the PR description warrants additional detail, add extra sections, for example notes on how to test (if required) -->

The config shared stack and then an SIS stack pointing to the recently deployed shared stack were deployed successfully

## Related PRs

<!-- Include links to any PRs, in this repo or others, related to this change, for example a related configuration change (delete this section if not applicable) -->
The shared stack changes: https://github.com/govuk-one-login/ipv-identity-reuse-service-config/pull/168 