### PR TITLE
BAU: Remove commitlint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,14 +56,6 @@ repos:
         language: system
         pass_filenames: false
 
-  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-    rev: v9.22.0
-    hooks:
-      - id: commitlint
-        stages: [ commit-msg ]
-        args: [ '--verbose' ]
-        verbose: true  # print warnings
-
   -   repo: https://github.com/jorisroovers/gitlint
       rev:  v0.19.1
       hooks:


### PR DESCRIPTION
## What

Remove the `commitlint` pre-commit action, this seems to have been copied from the EVCS repo and conflicts with the `gitlint` tool which we have been favouring in our repos for some time.

## Why

Both `commitlint` and `gitlint` do the same job but to different standards. `commitlint`, when not configured, favours conventional commits, where as we have `gitlint` to configured to favour rules described in the GDS Way.
