### PR TITLE
SPT-2009: Returns 500 on unrecoverable-error

### DIFF
--- a/openAPI/public-api.yaml
+++ b/openAPI/public-api.yaml
@@ -110,8 +110,8 @@ paths:
   /error/unrecoverable:
     get:
       responses:
-        "200":
-          description: OK
+        "500":
+          description: Internal Server Error
           content:
             text/html:
               schema:

--- a/src/handlers/get-unrecoverable-error-handler/get-unrecoverable-error-handler.ts
+++ b/src/handlers/get-unrecoverable-error-handler/get-unrecoverable-error-handler.ts
@@ -10,7 +10,7 @@ const nunjucksEnvironment = nunjucks.configure([process.env.LAMBDA_TASK_ROOT || 
 export const lambdaHandler = async (): Promise<APIGatewayProxyResult> => {
   try {
     return {
-      statusCode: 200,
+      statusCode: 500,
       body: nunjucksEnvironment.render(mainPageTemplate, {
         assetPath: "/assets",
         rootPath: "",

--- a/src/handlers/get-unrecoverable-error-handler/tests/get-unrecoverable-error-handler.test.ts
+++ b/src/handlers/get-unrecoverable-error-handler/tests/get-unrecoverable-error-handler.test.ts
@@ -40,7 +40,7 @@ it("should render the error screen", async () => {
     headers: {
       "content-type": "text/html",
     },
-    statusCode: 200,
+    statusCode: 500,
   });
 });
 


### PR DESCRIPTION
## What

- SPT-2009
- Returns 500 on unrecoverable-error

## Why

- We will want to build dashboard and alarms based on the 5xxError metric supplied API Gateway.