### PR TITLE
SPT-2008: Add /oauth2/authorize endpoint

### DIFF
--- a/openAPI/public-api.yaml
+++ b/openAPI/public-api.yaml
@@ -160,6 +160,34 @@ paths:
         requestParameters:
           integration.request.path.item: method.request.path.item
         type: aws
+  /oauth2/authorize:
+    get:
+      summary: Get an authorization grant
+      description: |
+        The authorization endpoint is used to interact with the resource owner
+        and obtain an authorization grant.
+      tags:
+        - Authorization
+      parameters:
+        - $ref: "#/components/parameters/ResponseTypeParam"
+        - $ref: "#/components/parameters/ClientIdParam"
+        - $ref: "#/components/parameters/RedirectUriParam"
+        - $ref: "#/components/parameters/ScopeParam"
+        - $ref: "#/components/parameters/StateParam"
+        - $ref: "#/components/parameters/RequestParam"
+      responses:
+        "302":
+          $ref: "#/components/responses/AuthorizationRedirect"
+      x-amazon-apigateway-request-validator: ALL
+      x-amazon-apigateway-integration:
+        httpMethod: POST
+        uri:
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${GetAuthorizeHandler.Arn}:live/invocations
+        credentials:
+          Fn::GetAtt: GetAuthorizeHandlerRestApiRole.Arn
+        passthroughBehavior: NEVER
+        contentHandling: CONVERT_TO_TEXT
+        type: AWS_PROXY
   /oauth2/callback:
     get:
       responses:

--- a/tests/acceptance/steps/utils/auth-api.ts
+++ b/tests/acceptance/steps/utils/auth-api.ts
@@ -72,7 +72,7 @@ export const isAuthorizationResponse = (response: unknown): response is Authoriz
 export const authorize = async (parameters: AuthorizationParameters): Promise<RedirectResponse | Error> => {
   const publicApi = await getCloudFormationOutput(CloudFormationOutputs.SisPublicApi);
 
-  const response = await request(publicApi).get("/authorize").query(parameters).send();
+  const response = await request(publicApi).get("/oauth2/authorize").query(parameters).send();
   if (isAwsError(response.body)) {
     return new Error("error", { cause: response.body.message });
   }


### PR DESCRIPTION
# What

First part of ZDD PRs for SPT-2008.

- This adds /oauth2/authorize as a duplicate of /authorize
- Acceptance test uses the new path.

# Why

To ensure SIS is a contract match with IPV Core, we should ensure our endpoint paths match theirs.

