### PR TITLE
SPT-1968: Updated Post confirm details lambda to redirect to the GET /oauth2/common endpoint

### DIFF
--- a/infrastructure/identity-reuse-service/samconfig.toml
+++ b/infrastructure/identity-reuse-service/samconfig.toml
@@ -1,10 +1,13 @@
 version = 0.1
 
+[default.build.parameters]
+parallel = true
+
 [default.deploy.parameters]
 resolve_s3 = true
 region = "eu-west-2"
 confirm_changeset = false
 capabilities = "CAPABILITY_NAMED_IAM"
 disable_rollback = false
-parameter_overrides = "VpcStackName=\"vpc\" LogGroupRetentionInDays=\"30\""
+parameter_overrides = "VpcStackName=\"vpc\" LogGroupRetentionInDays=\"30\" Environment=\"dev\" OauthInternalStackName=\"preview-main-oauth\""
 image_repositories = []

--- a/infrastructure/identity-reuse-service/template.yaml
+++ b/infrastructure/identity-reuse-service/template.yaml
@@ -84,7 +84,7 @@ Parameters:
   OauthInternalStackName:
     Description: OAuth Internal Stack name
     Type: String
-    Default: "sis-oauth-internal"
+    Default: preview-main-oauth
 
   DynatraceNodeLayerArn:
     Type: String

--- a/infrastructure/identity-reuse-service/template.yaml
+++ b/infrastructure/identity-reuse-service/template.yaml
@@ -84,7 +84,7 @@ Parameters:
   OauthInternalStackName:
     Description: OAuth Internal Stack name
     Type: String
-    Default: preview-main-oauth
+    Default: "sis-oauth-internal"
 
   DynatraceNodeLayerArn:
     Type: String
@@ -1075,6 +1075,7 @@ Resources:
       Environment:
         Variables:
           NODE_OPTIONS: "--enable-source-maps"
+          PUBLIC_API: !GetAtt ReuseIdentityDomain.Value
     Metadata:
       BuildMethod: esbuild
       BuildProperties:

--- a/infrastructure/oauth-internal/template.yaml
+++ b/infrastructure/oauth-internal/template.yaml
@@ -106,6 +106,16 @@ Parameters:
     Type: String
     Default: vpc
 
+  OrchestrationJwksEndpointOverride:
+    Type: String
+    Description: Override for the default OrchestrationJwksEndpoint for the environment
+    Default: none
+
+  OrchestrationRedirectURIOverride:
+    Type: String
+    Description: Override for the default OrchestrationRedirectURI for the environment
+    Default: none
+
 Mappings:
   EnvironmentMap:
     "local":
@@ -158,6 +168,14 @@ Conditions:
       - Fn::Equals: [ !Ref Environment, "build" ]
       - Fn::Equals: [ !Ref Environment, "staging" ]
 
+  IsOrchestrationJwksEndpointOverridden:
+    Fn::Not:
+      - Fn::Equals: [ !Ref OrchestrationJwksEndpointOverride, "none" ]
+
+  IsOrchestrationRedirectURIOverridden:
+    Fn::Not:
+      - Fn::Equals: [ !Ref OrchestrationRedirectURIOverride, "none" ]
+
 Resources:
   OAuthCommon:
     Type: AWS::Serverless::Application
@@ -176,8 +194,14 @@ Resources:
         CriPrivateApiGwName: !Sub "${AWS::StackName}-PrivateApi" # Used to create canary deployment alarms for the stack
         CriPublicApiGwName: !Sub "${AWS::StackName}-PrivateApi" # This will become the external facing private API when the /token endpoint moves there
         Environment: !If [IsDev, dev, !Ref Environment ]
-        IPVCoreRedirectURI: !FindInMap [ EnvironmentMap, !Ref Environment, OrchestrationRedirectURI ] # The expected client redirect URI (used in staging upwards)
-        IPVCoreStubJwksEndpoint: !FindInMap [ EnvironmentMap, !Ref Environment, OrchestrationJwksEndpoint ] # The expected client JWKS endpoint (used in non-prod)
+        IPVCoreRedirectURI: !If
+          - IsOrchestrationRedirectURIOverridden
+          - !Ref OrchestrationRedirectURIOverride
+          - !FindInMap [ EnvironmentMap, !Ref Environment, OrchestrationRedirectURI ] # The expected client redirect URI (used in staging upwards)
+        IPVCoreStubJwksEndpoint: !If
+          - IsOrchestrationJwksEndpointOverridden
+          - !Ref OrchestrationJwksEndpointOverride
+          - !FindInMap [ EnvironmentMap, !Ref Environment, OrchestrationJwksEndpoint ] # The expected client JWKS endpoint (used in non-prod)
         IsCredentialIssuer: "false"
         LambdaCodeSigningConfigArn: !Ref CodeSigningConfigArn
         LambdaDeploymentPreference: !Ref LambdaDeploymentPreference
@@ -343,7 +367,10 @@ Resources:
     Properties:
       Name: !Sub "/${OAuthCommon.Outputs.StackName}/clients/${OAuthClientId}/jwtAuthentication/redirectUri"
       Type: String
-      Value: !FindInMap [ EnvironmentMap, !Ref Environment, OrchestrationRedirectURI ]
+      Value: !If
+        - IsOrchestrationRedirectURIOverridden
+        - !Ref OrchestrationRedirectURIOverride
+        - !FindInMap [ EnvironmentMap, !Ref Environment, OrchestrationRedirectURI ]
 
   IPVCoreJwksEndpointParameter:
     Type: AWS::SSM::Parameter
@@ -351,7 +378,10 @@ Resources:
     Properties:
       Name: !Sub "/${OAuthCommon.Outputs.StackName}/clients/${OAuthClientId}/jwtAuthentication/jwksEndpoint"
       Type: String
-      Value: !FindInMap [ EnvironmentMap, !Ref Environment, OrchestrationJwksEndpoint ]
+      Value: !If
+        - IsOrchestrationJwksEndpointOverridden
+        - !Ref OrchestrationJwksEndpointOverride
+        - !FindInMap [ EnvironmentMap, !Ref Environment, OrchestrationJwksEndpoint ]
 
 Outputs:
   PrivateApi:

--- a/src/handlers/get-authorize-handler/get-authorize-handler.ts
+++ b/src/handlers/get-authorize-handler/get-authorize-handler.ts
@@ -39,10 +39,15 @@ function redirectToError(domainName: string): APIGatewayProxyResult {
   };
 }
 
-function redirectToConfirmDetails(domainName: string, sessionResponse: SessionResponse): APIGatewayProxyResult {
+function redirectToConfirmDetails(
+  domainName: string,
+  sessionResponse: SessionResponse,
+  clientId: string
+): APIGatewayProxyResult {
   const url = new URL("/confirm-details", `https://${domainName}`);
   url.searchParams.append("state", sessionResponse.state);
   url.searchParams.append("redirect_uri", sessionResponse.redirect_uri);
+  url.searchParams.append("client_id", clientId);
 
   return {
     statusCode: 302,
@@ -119,5 +124,5 @@ async function createSession(clientId: string, request: string, domainName: stri
 
   const sessionResponse: SessionResponse = await response.json();
 
-  return redirectToConfirmDetails(domainName, sessionResponse);
+  return redirectToConfirmDetails(domainName, sessionResponse, clientId);
 }

--- a/src/handlers/get-authorize-handler/tests/get-authorize-handler.test.ts
+++ b/src/handlers/get-authorize-handler/tests/get-authorize-handler.test.ts
@@ -102,7 +102,7 @@ describe("authorize-handler", () => {
       expect(response.statusCode).toBe(302);
 
       expect(response.headers?.Location).toBe(
-        "https://test-domain/confirm-details?state=test-state&redirect_uri=https%3A%2F%2Fsome.redirect.com"
+        "https://test-domain/confirm-details?state=test-state&redirect_uri=https%3A%2F%2Fsome.redirect.com&client_id=orchestrator"
       );
 
       const expectedCookie = [

--- a/src/handlers/get-confirm-details-handler/get-confirm-details-handler.ts
+++ b/src/handlers/get-confirm-details-handler/get-confirm-details-handler.ts
@@ -9,12 +9,13 @@ const nunjucksEnvironment = nunjucks.configure([process.env.LAMBDA_TASK_ROOT || 
 
 export type ConfirmDetailsQueryStringParameters = {
   redirect_uri: string;
+  client_id: string;
   state: string;
 };
 
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
-  const { redirect_uri, state } = event.queryStringParameters as ConfirmDetailsQueryStringParameters;
-  if (!redirect_uri || !state) {
+  const { redirect_uri, client_id, state } = event.queryStringParameters as ConfirmDetailsQueryStringParameters;
+  if (!redirect_uri || !state || !client_id) {
     throw new Error("One or more required query string parameters are undefined or empty");
   }
   try {
@@ -25,6 +26,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
         rootPath: ".",
         redirect_uri,
         state,
+        client_id,
       }),
       headers: {
         "content-type": "text/html",

--- a/src/handlers/get-confirm-details-handler/index.njk
+++ b/src/handlers/get-confirm-details-handler/index.njk
@@ -71,6 +71,12 @@
                       name: "state",
                       value: state
                     }) }}
+                    {{ govukInput({
+                      type: "hidden",
+                      id: "client_id",
+                      name: "client_id",
+                      value: client_id
+                    }) }}
                     {{ govukButton({
                     text: "Continue"
                     }) }}

--- a/src/handlers/get-confirm-details-handler/tests/get-confirm-details-handler.test.ts
+++ b/src/handlers/get-confirm-details-handler/tests/get-confirm-details-handler.test.ts
@@ -23,6 +23,7 @@ it("should render the confirm details screen when all query string parameters ar
     queryStringParameters: {
       redirect_uri: "https://example.com",
       state: "state-id",
+      client_id: "client",
     },
   } as never as APIGatewayProxyEvent);
 
@@ -33,6 +34,7 @@ it("should render the confirm details screen when all query string parameters ar
       redirect_uri: "https://example.com",
       state: "state-id",
       rootPath: ".",
+      client_id: "client",
     }
   );
 

--- a/src/handlers/post-confirm-details-handler/post-confirm-details-handler.ts
+++ b/src/handlers/post-confirm-details-handler/post-confirm-details-handler.ts
@@ -11,9 +11,14 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
     throw new Error("One or more required query string parameters are undefined");
   }
 
-  const url = new URL(decodeURIComponent(eventValues.get("redirectUri") || ""));
-  url.searchParams.append("code", "SplxlOBeZQQYbYS6WxSbIA");
-  url.searchParams.append("state", eventValues.get("state") || "");
+  // const url = new URL(decodeURIComponent(eventValues.get("redirectUri") || ""));
+  // url.searchParams.append("code", "SplxlOBeZQQYbYS6WxSbIA");
+  // url.searchParams.append("state", eventValues.get("state") || "");
+
+  const url = new URL("/oauth2/common");
+  url.searchParams.append("redirect_uri", "whoknows");
+  url.searchParams.append("state", "whoknows");
+  url.searchParams.append("client_id", "whoknows");
 
   try {
     return {

--- a/src/handlers/post-confirm-details-handler/post-confirm-details-handler.ts
+++ b/src/handlers/post-confirm-details-handler/post-confirm-details-handler.ts
@@ -5,20 +5,17 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
   const eventValues = new URLSearchParams(event.body || "");
 
   const redirectUri = eventValues.get("redirectUri");
+  const clientId = eventValues.get("client_id");
   const state = eventValues.get("state");
 
-  if (!redirectUri || !state) {
+  if (!redirectUri || !state || !clientId) {
     throw new Error("One or more required query string parameters are undefined");
   }
 
-  // const url = new URL(decodeURIComponent(eventValues.get("redirectUri") || ""));
-  // url.searchParams.append("code", "SplxlOBeZQQYbYS6WxSbIA");
-  // url.searchParams.append("state", eventValues.get("state") || "");
-
-  const url = new URL("/oauth2/common");
-  url.searchParams.append("redirect_uri", "whoknows");
-  url.searchParams.append("state", "whoknows");
-  url.searchParams.append("client_id", "whoknows");
+  const url = new URL(`https://${process.env.PUBLIC_API}/oauth2/callback`);
+  url.searchParams.append("redirect_uri", redirectUri);
+  url.searchParams.append("state", state);
+  url.searchParams.append("client_id", clientId);
 
   try {
     return {

--- a/src/handlers/post-confirm-details-handler/tests/post-confirm-details-handler.test.ts
+++ b/src/handlers/post-confirm-details-handler/tests/post-confirm-details-handler.test.ts
@@ -1,18 +1,26 @@
 import { APIGatewayEventRequestContextWithAuthorizer, APIGatewayProxyEvent } from "aws-lambda";
-import { expect, it } from "vitest";
+import { expect, it, vi } from "vitest";
 import { lambdaHandler } from "../post-confirm-details-handler";
 
 it("should return a 302 status code on a successful request", async () => {
-  const event = createMockAPIGatewayProxyEvent({}, "redirectUri=https%3A%2F%2Fapi.example.com&state=test-state-id");
+  vi.stubEnv("PUBLIC_API", "api.example.com");
+
+  const event = createMockAPIGatewayProxyEvent(
+    {},
+    "redirectUri=https%3A%2F%2Fapi.example.com&state=test-state-id&client_id=client"
+  );
 
   const response = await lambdaHandler(event);
   expect(response).toStrictEqual({
     statusCode: 302,
     body: "",
     headers: {
-      Location: "https://api.example.com/?code=SplxlOBeZQQYbYS6WxSbIA&state=test-state-id",
+      Location:
+        "https://api.example.com/oauth2/callback?redirect_uri=https%3A%2F%2Fapi.example.com&state=test-state-id&client_id=client",
     },
   });
+
+  vi.unstubAllEnvs();
 });
 
 it("should return an error when some query string parameters are missing", async () => {


### PR DESCRIPTION
## What

Updated the following endpoints to enable the Post conform details lambda to redirect to the `GET /oauth2/common` endpoint:
* `get-authorize-handler` and get-confirm-details-handler now passes through the client_id downstream.
* `post-confirm-details-handler` now calls the /oauth2/common endpoint with the client_id.

Updated CloudFormation to include the following parameters for the `oauth-internal` stack.
* `OrchestrationJwksEndpointOverride` - Override for the default `OrchestrationJwksEndpoint` for the environment.
* `OrchestrationRedirectURIOverride` - Override for the default `OrchestrationRedirectURI` for the environment.

## Why

* Lambda updates - Following the Confirm Details screen the user should be redirected to the `/oauth2/common` endpoint to continue their journey. The `/oauth2/common` endpoint requires the `client_id` parameter which was not being passed through the different steps.

* Cloud Formation updates - The Cloud Formation stacks contained hard coded values to the Stored Identity Services Public and Private APIs. This made it very hard from a developer perspective to deploy their own copy of the Stored Identity Service as they would need to update the Cloud Formation directly. Whereas the new parameters enable a very minor change on the command line or a developers `samconfig.toml` file.

## Manual Testing

### Steps to Test

The following was done to test this functionality:
1. Deployed Stored Identity Service to environment
1. Deployed Orchestration Stub using the outputs from the Stored Identity Service
1. Ran a journey using the defaults
1. At the "You have already proved your identity" screen:
  1. Opened the browser development tools
  2. Look for the value of the `identity_reuse_service_session`
  3. Look at OAuth Common DynamoDb session table and where the `sessionId` is the value of `identity_reuse_service_session`
  4. Edited the record adding an `authorizationCode` with any value
1. Clicked Continue

### Expected Result

#### Image showing DynamoDb record:

<img width="1641" height="240" alt="Screenshot 2026-07-24 at 08 35 59" src="https://github.com/user-attachments/assets/f4822755-9411-486d-b39f-f82dd622b434" />

#### Image showing final screen include `code` in the address bar:

<img width="1311" height="834" alt="Screenshot 2026-07-24 at 08 43 08" src="https://github.com/user-attachments/assets/0e4d0162-3140-4181-95be-3367eeb331f0" />

## Related PRs

<!-- Include links to any PRs, in this repo or others, related to this change, for example a related configuration change (delete this section if not applicable) -->
