### PR TITLE
SPT-2019: adds new AuditEventQueueSendMessagePolicy

### DIFF
--- a/infrastructure/identity-reuse-service/template.yaml
+++ b/infrastructure/identity-reuse-service/template.yaml
@@ -436,6 +436,7 @@ Resources:
         - arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess
         - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
         - Fn::ImportValue: !Sub "${AppConfigStackName}-AppConfigClientPolicyArn"
+        - Fn::ImportValue: !Sub "${SharedStackName}-AuditEventQueueSendMessagePolicy"
       Tags:
         - Key: Product
           Value: !Ref ProductTagValue
@@ -621,6 +622,7 @@ Resources:
         - arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess
         - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
         - Fn::ImportValue: !Sub "${AppConfigStackName}-AppConfigClientPolicyArn"
+        - Fn::ImportValue: !Sub "${SharedStackName}-AuditEventQueueSendMessagePolicy"
       Tags:
         - Key: Product
           Value: !Ref ProductTagValue
@@ -1750,6 +1752,7 @@ Resources:
         - arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess
         - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
         - Fn::ImportValue: !Sub "${AppConfigStackName}-AppConfigClientPolicyArn"
+        - Fn::ImportValue: !Sub "${SharedStackName}-AuditEventQueueSendMessagePolicy"
       Tags:
         - Key: Product
           Value: !Ref ProductTagValue
@@ -2082,6 +2085,7 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
         - Fn::ImportValue: !Sub "${AppConfigStackName}-AppConfigClientPolicyArn"
+        - Fn::ImportValue: !Sub "${SharedStackName}-AuditEventQueueSendMessagePolicy"
       Tags:
         - Key: Product
           Value: !Ref ProductTagValue


### PR DESCRIPTION
## What

<!-- Describe the changes in detail - the "what"-->
<!-- Include all information the reviewer needs for context -->

- `AuditEventQueueSendMessagePolicy` is being imported as a Managed Policy to the lambda function roles (see below) which currently require the `sqs:SendMessage` permission to the shared stack's `AuditEventQueue`
- It has been added to:
    - `PostPhase2UserIdentityHandlerRole`
    - `GetUserIdentityHandlerRole`
    - `GetAuthorizeHandlerRole`
    - `InboundTxmaQueueMessageHandlerRole`

## Why

<!-- Describe the reason these changes were made - the "why" -->
<!-- Include all information the reviewer needs for context -->

- This will replace the existing sendMessage permissions, removal will be in a followup PR

## additional sections as needed

<!-- if you feel the PR description warrants additional detail, add extra sections, for example notes on how to test (if required) -->

## Related PRs

<!-- Include links to any PRs, in this repo or others, related to this change, for example a related configuration change (delete this section if not applicable) -->
SIS config PR with the shared stack update: https://github.com/govuk-one-login/ipv-identity-reuse-service-config/pull/178 