### PR TITLE
SPT-2019: removes old permissions, adds EvcsApiKeySecretsManagerPolicy

### DIFF
--- a/infrastructure/identity-reuse-service/template.yaml
+++ b/infrastructure/identity-reuse-service/template.yaml
@@ -459,19 +459,9 @@ Resources:
         Statement:
           - Effect: Allow
             Action:
-              - kms:Decrypt
-              - kms:GenerateDataKey
-            Resource: "*"
-          - Effect: Allow
-            Action:
               - "secretsmanager:GetSecretValue" #pragma: allowlist secret
             Resource:
               - Fn::ImportValue: !Sub "${SharedStackName}-EVCSApiKeySecret"
-          - Effect: Allow
-            Action:
-              - sqs:SendMessage
-            Resource:
-              Fn::ImportValue: !Sub "${SharedStackName}-AuditEventQueueArn"
       Roles:
         - !Ref GetAuthorizeHandlerRole
 
@@ -645,19 +635,9 @@ Resources:
         Statement:
           - Effect: Allow
             Action:
-              - kms:Decrypt
-              - kms:GenerateDataKey
-            Resource: "*"
-          - Effect: Allow
-            Action:
               - "secretsmanager:GetSecretValue" #pragma: allowlist secret
             Resource:
               - Fn::ImportValue: !Sub "${SharedStackName}-EVCSApiKeySecret"
-          - Effect: Allow
-            Action:
-              - sqs:SendMessage
-            Resource:
-              Fn::ImportValue: !Sub "${SharedStackName}-AuditEventQueueArn"
       Roles:
         - !Ref GetUserIdentityHandlerRole
 
@@ -1774,19 +1754,9 @@ Resources:
         Statement:
           - Effect: Allow
             Action:
-              - kms:Decrypt
-              - kms:GenerateDataKey
-            Resource: "*"
-          - Effect: Allow
-            Action:
               - "secretsmanager:GetSecretValue" #pragma: allowlist secret
             Resource:
               - Fn::ImportValue: !Sub "${SharedStackName}-EVCSApiKeySecret"
-          - Effect: Allow
-            Action:
-              - sqs:SendMessage
-            Resource:
-              Fn::ImportValue: !Sub "${SharedStackName}-AuditEventQueueArn"
       Roles:
         - !Ref PostPhase2UserIdentityHandlerRole
 
@@ -2116,11 +2086,6 @@ Resources:
               - IsDevOrBuild
               - !GetAtt StubQueue.Arn
               - !FindInMap [EnvironmentMap, !Ref Environment, InboundTxmaQueueArn]
-          - Effect: Allow
-            Action:
-              - sqs:SendMessage
-            Resource:
-              Fn::ImportValue: !Sub "${SharedStackName}-AuditEventQueueArn"
           - Effect: Allow
             Action:
               - kms:Decrypt

--- a/infrastructure/identity-reuse-service/template.yaml
+++ b/infrastructure/identity-reuse-service/template.yaml
@@ -437,6 +437,7 @@ Resources:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
         - Fn::ImportValue: !Sub "${AppConfigStackName}-AppConfigClientPolicyArn"
         - Fn::ImportValue: !Sub "${SharedStackName}-AuditEventQueueSendMessagePolicy"
+        - Fn::ImportValue: !Sub "${SharedStackName}-EvcsApiKeySecretsManagerPolicy"
       Tags:
         - Key: Product
           Value: !Ref ProductTagValue
@@ -613,6 +614,7 @@ Resources:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
         - Fn::ImportValue: !Sub "${AppConfigStackName}-AppConfigClientPolicyArn"
         - Fn::ImportValue: !Sub "${SharedStackName}-AuditEventQueueSendMessagePolicy"
+        - Fn::ImportValue: !Sub "${SharedStackName}-EvcsApiKeySecretsManagerPolicy"
       Tags:
         - Key: Product
           Value: !Ref ProductTagValue
@@ -1733,6 +1735,7 @@ Resources:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
         - Fn::ImportValue: !Sub "${AppConfigStackName}-AppConfigClientPolicyArn"
         - Fn::ImportValue: !Sub "${SharedStackName}-AuditEventQueueSendMessagePolicy"
+        - Fn::ImportValue: !Sub "${SharedStackName}-EvcsApiKeySecretsManagerPolicy"
       Tags:
         - Key: Product
           Value: !Ref ProductTagValue
@@ -2056,6 +2059,7 @@ Resources:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
         - Fn::ImportValue: !Sub "${AppConfigStackName}-AppConfigClientPolicyArn"
         - Fn::ImportValue: !Sub "${SharedStackName}-AuditEventQueueSendMessagePolicy"
+        - Fn::ImportValue: !Sub "${SharedStackName}-EvcsApiKeySecretsManagerPolicy"
       Tags:
         - Key: Product
           Value: !Ref ProductTagValue
@@ -2099,10 +2103,10 @@ Resources:
               - "secretsmanager:GetSecretValue" #pragma: allowlist secret
             Resource:
               - Fn::ImportValue: !Sub "${SharedStackName}-EVCSApiKeySecret"
-          - Effect: Allow
-            Action:
-              - "kms:*"
-            Resource: "*"
+#          - Effect: Allow
+#            Action:
+#              - "kms:*"
+#            Resource: "*"
       Roles:
         - !Ref InboundTxmaQueueMessageHandlerRole
 


### PR DESCRIPTION
## What

<!-- Describe the changes in detail - the "what"-->
<!-- Include all information the reviewer needs for context -->

- `sqs:SendMessage` permissions for the audit event queue from the shared stack have been removed
- Instances of KMS policies (`Decrypt` and `GenerateDataKey`) where resources were * have also been removed
- Adds `EvcsApiKeySecretsManagerPolicy` from Shared Stack

## Why

<!-- Describe the reason these changes were made - the "why" -->
<!-- Include all information the reviewer needs for context -->

- Tidying up old permissions which were replaced by `AuditEventQueueSendMessagePolicy` 
- `EvcsApiKeySecretsManagerPolicy` was added because the KMS key for the EVCS secret needed more permissions

## additional sections as needed

<!-- if you feel the PR description warrants additional detail, add extra sections, for example notes on how to test (if required) -->

## Related PRs

<!-- Include links to any PRs, in this repo or others, related to this change, for example a related configuration change (delete this section if not applicable) -->
Previous PR adding the new policy: https://github.com/govuk-one-login/ipv-identity-reuse-service/pull/414 