### PR TITLE
SPT-1968: PostConfirmDetails call CreateAuthCodeFn

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -159,7 +159,7 @@
         "filename": "infrastructure/identity-reuse-service/template.yaml",
         "hashed_secret": "aa1dd0ad4d2da161dd67db89e3d1aff921426385",
         "is_verified": false,
-        "line_number": 291,
+        "line_number": 292,
         "is_secret": false
       },
       {
@@ -167,7 +167,7 @@
         "filename": "infrastructure/identity-reuse-service/template.yaml",
         "hashed_secret": "5f784906cd85d6336c8506e9da9d102405771429",
         "is_verified": false,
-        "line_number": 297,
+        "line_number": 298,
         "is_secret": false
       },
       {
@@ -175,7 +175,7 @@
         "filename": "infrastructure/identity-reuse-service/template.yaml",
         "hashed_secret": "1ef0d2ac7a97bfe12f63f5d79979f912500adae1",
         "is_verified": false,
-        "line_number": 303,
+        "line_number": 304,
         "is_secret": false
       },
       {
@@ -183,7 +183,7 @@
         "filename": "infrastructure/identity-reuse-service/template.yaml",
         "hashed_secret": "5f399dc88587898510cf56b7503b482c870d0121",
         "is_verified": false,
-        "line_number": 309,
+        "line_number": 310,
         "is_secret": false
       },
       {
@@ -191,10 +191,10 @@
         "filename": "infrastructure/identity-reuse-service/template.yaml",
         "hashed_secret": "dc2050b23f4157e1b630f2bdf2f0a76b82f0f51a",
         "is_verified": false,
-        "line_number": 315,
+        "line_number": 316,
         "is_secret": false
       }
     ]
   },
-  "generated_at": "2026-07-09T14:29:15Z"
+  "generated_at": "2026-07-30T12:58:54Z"
 }

--- a/infrastructure/identity-reuse-service/template.yaml
+++ b/infrastructure/identity-reuse-service/template.yaml
@@ -284,6 +284,7 @@ Globals:
       - arm64
     Environment:
       Variables:
+        POWERTOOLS_METRICS_NAMESPACE: !GetAtt MainCloudWatchMetricNamespaceName.Value
         AWS_LAMBDA_EXEC_WRAPPER: !If [DynaTraceEnabled, "/opt/dynatrace", !Ref "AWS::NoValue"]
         DT_CONNECTION_AUTH_TOKEN: !If
           - DynaTraceEnabled
@@ -375,8 +376,6 @@ Resources:
       Environment:
         Variables:
           METRIC_SERVICE_NAME: "GetAuthorizeHandler"
-          POWERTOOLS_METRICS_NAMESPACE:
-            !If [IsDev, !Sub "${AWS::StackName}-GetAuthorizeHandler", "GetAuthorizeHandler"]
           POWERTOOLS_SERVICE_NAME: "GetAuthorizeHandler"
           ENVIRONMENT: !If [IsDev, "dev", !Ref Environment]
           APP_CONFIG_NAME: !Ref ApplicationConfigName
@@ -563,8 +562,6 @@ Resources:
           METRIC_SERVICE_NAME: "GetUserIdentityHandler"
           EVCS_API_KEY_SECRET_ARN:
             Fn::ImportValue: !Sub "${SharedStackName}-EVCSApiKeySecret"
-          POWERTOOLS_METRICS_NAMESPACE:
-            !If [IsDev, !Sub "${AWS::StackName}-GetUserIdentityHandler", "GetUserIdentityHandler"]
           POWERTOOLS_SERVICE_NAME: "GetUserIdentityHandler"
           ENVIRONMENT: !If [IsDev, "dev", !Ref Environment]
           APP_CONFIG_NAME: !Ref ApplicationConfigName
@@ -954,6 +951,7 @@ Resources:
       Environment:
         Variables:
           NODE_OPTIONS: "--enable-source-maps"
+          POWERTOOLS_SERVICE_NAME: "GetConfirmDetailsHandler"
       Layers:
         - !Ref GovUKFrontEndLayer
         - !If
@@ -1074,8 +1072,12 @@ Resources:
       Role: !GetAtt PostConfirmDetailsHandlerRole.Arn
       Environment:
         Variables:
+          DOMAIN_NAME: !Ref ReuseIdentityCustomDomain
           NODE_OPTIONS: "--enable-source-maps"
+          OAUTH_INTERNAL_API_URL:
+            Fn::ImportValue: !Sub "${OauthInternalStackName}-PrivateApi"
           PUBLIC_API: !GetAtt ReuseIdentityDomain.Value
+          POWERTOOLS_SERVICE_NAME: "PostConfirmDetailsHandler"
     Metadata:
       BuildMethod: esbuild
       BuildProperties:
@@ -1181,6 +1183,7 @@ Resources:
       Environment:
         Variables:
           NODE_OPTIONS: "--enable-source-maps"
+          POWERTOOLS_SERVICE_NAME: "GetUnrecoverableErrorHandler"
       Layers:
         - !Ref GovUKFrontEndLayer
         - !If
@@ -1303,11 +1306,9 @@ Resources:
         Variables:
           NODE_OPTIONS: "--enable-source-maps"
           DOMAIN_NAME: !Ref ReuseIdentityCustomDomain
-          OAUTH_INTERNAL_API:
-            Fn::Sub:
-              - "${OauthInternalStackId}"
-              - OauthInternalStackId:
-                  Fn::ImportValue: !Sub "${OauthInternalStackName}-PrivateApi"
+          POWERTOOLS_SERVICE_NAME: "GetCallbackHandler"
+          OAUTH_INTERNAL_API_URL:
+            Fn::ImportValue: !Sub "${OauthInternalStackName}-PrivateApi"
       Layers:
         - !Ref GovUKFrontEndLayer
         - !If
@@ -1693,8 +1694,6 @@ Resources:
           METRIC_SERVICE_NAME: "UserIdentityFunction"
           EVCS_API_KEY_SECRET_ARN:
             Fn::ImportValue: !Sub "${SharedStackName}-EVCSApiKeySecret"
-          POWERTOOLS_METRICS_NAMESPACE:
-            !If [IsDev, !Sub "${AWS::StackName}-UserIdentityFunction", "UserIdentityFunction"]
           POWERTOOLS_SERVICE_NAME: "PostPhase2UserIdentityHandler"
           ENVIRONMENT: !If [IsDev, "dev", !Ref Environment]
           APP_CONFIG_NAME: !Ref ApplicationConfigName
@@ -2030,8 +2029,6 @@ Resources:
       Role: !GetAtt InboundTxmaQueueMessageHandlerRole.Arn
       Environment:
         Variables:
-          POWERTOOLS_METRICS_NAMESPACE:
-            !If [IsDev, !Sub "${AWS::StackName}-TXMAMessageProcessor", "TXMAMessageProcessor"]
           POWERTOOLS_SERVICE_NAME: "MessagesReceived"
           EVCS_API_KEY_SECRET_ARN:
             Fn::ImportValue: !Sub "${SharedStackName}-EVCSApiKeySecret"
@@ -2159,8 +2156,17 @@ Resources:
       LogGroupName: !Ref InboundTxmaQueueMessageHandlerLogGroup
       MetricTransformations:
         - MetricName: !Sub "${InboundTxmaQueueMessageHandler}-LambdaError"
-          MetricNamespace: !Ref MainCloudWatchMetricNamespace
+          MetricNamespace: !GetAtt MainCloudWatchMetricNamespaceName.Value
           MetricValue: "1"
+
+  MainCloudWatchMetricNamespaceName:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Type: String
+      Value: !If
+        - IsDev
+        - !Sub "${AWS::StackName}-${MainCloudWatchMetricNamespace}"
+        - !Ref MainCloudWatchMetricNamespace
 
   #######
   # API #

--- a/infrastructure/oauth-internal/template.yaml
+++ b/infrastructure/oauth-internal/template.yaml
@@ -183,7 +183,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:eu-west-2:667736788427:applications/di-ipv-cri-oauth-common
-        SemanticVersion: 0.5.0
+        SemanticVersion: 0.8.0
       Parameters:
         AuditEventNamePrefix: !Ref AuditEventNamePrefix
         AuditTxmaStackName: !Ref SharedStackName # TXMA infrastructure lives in the reuse-identity-shared stack

--- a/openAPI/oauth-common-private-api.yaml
+++ b/openAPI/oauth-common-private-api.yaml
@@ -87,6 +87,36 @@ paths:
           Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${OAuthCommon.Outputs.LambdaAuthorizationFunctionName}:live/invocations
         passthroughBehavior: never
 
+  /api/create-auth-code:
+    post:
+      summary: "Create authorization code for a session"
+      parameters:
+        - $ref: "#/components/parameters/SessionHeader"
+      responses:
+        "200":
+          description: The authorization code already exists for the user
+        "201":
+          description: The authorization code was created for the session
+        "400":
+          description: A bad request error with a message
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: An internal server error with a message
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+      x-amazon-apigateway-request-validator: ALL
+      x-amazon-apigateway-integration:
+        type: aws_proxy
+        httpMethod: POST
+        uri:
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${OAuthCommon.Outputs.LambdaCreateAuthCodeFunctionName}:live/invocations
+        passthroughBehavior: never
+
 components:
   parameters:
     SessionHeader:

--- a/src/commons/redirect-utilities.ts
+++ b/src/commons/redirect-utilities.ts
@@ -1,0 +1,10 @@
+export const redirectToErrorPage = async (domainName: string) =>
+  await redirect(`https://${domainName}/error/unrecoverable`);
+
+export const redirect = async (location: string) => ({
+  statusCode: 302,
+  headers: {
+    Location: location,
+  },
+  body: "",
+});

--- a/src/handlers/get-callback-handler/get-callback-handler.ts
+++ b/src/handlers/get-callback-handler/get-callback-handler.ts
@@ -4,6 +4,7 @@ import { URL } from "node:url";
 import { getCookieValues } from "../../commons/cookie-utilities";
 import { AuthorizationSuccessResponse, isValidSuccessResponse } from "./get-callback-response";
 import { isValidQueryParameters } from "./get-callback-request";
+import { redirect, redirectToErrorPage } from "../../commons/redirect-utilities";
 
 export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
   const queryParameters = event.queryStringParameters || {};
@@ -21,15 +22,15 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
     return await redirectToErrorPage(domainName);
   }
 
-  const oauthInternalApiUrl = process.env.OAUTH_INTERNAL_API;
-  const url = new URL(`${oauthInternalApiUrl}/api/authorization`);
-
-  url.searchParams.append("client_id", queryParameters.client_id);
-  url.searchParams.append("redirect_uri", queryParameters.redirect_uri);
-  url.searchParams.append("state", queryParameters.state);
-  url.searchParams.append("response_type", "code");
-
   try {
+    const oauthInternalApiUrl = process.env.OAUTH_INTERNAL_API_URL;
+    const url = new URL(`${oauthInternalApiUrl}/api/authorization`);
+
+    url.searchParams.append("client_id", queryParameters.client_id);
+    url.searchParams.append("redirect_uri", queryParameters.redirect_uri);
+    url.searchParams.append("state", queryParameters.state);
+    url.searchParams.append("response_type", "code");
+
     const responseFromAuthorizeEndpoint = await fetch(url, {
       method: "GET",
       headers: {
@@ -71,18 +72,4 @@ const redirectToClientWithError = async (redirectUri: string, state: string) => 
   // To be replaced with the state returned by the /authorization endpoint once it's added to the oauth-common response
   orchestrationRedirectUrl.searchParams.append("state", state);
   return redirect(`${orchestrationRedirectUrl}`);
-};
-
-const redirectToErrorPage = async (domainName: string) => {
-  return await redirect(`https://${domainName}/error/unrecoverable`);
-};
-
-const redirect = async (location: string) => {
-  return {
-    statusCode: 302,
-    headers: {
-      Location: location,
-    },
-    body: "",
-  };
 };

--- a/src/handlers/get-callback-handler/tests/get-callback-handler.test.ts
+++ b/src/handlers/get-callback-handler/tests/get-callback-handler.test.ts
@@ -4,7 +4,7 @@ import { handler } from "../get-callback-handler";
 import { getCookieValues } from "../../../commons/cookie-utilities";
 
 process.env.DOMAIN_NAME = "test-domain";
-process.env.OAUTH_INTERNAL_API = "https://test.com";
+process.env.OAUTH_INTERNAL_API_URL = "https://test.com";
 
 const { mockError } = vitest.hoisted(() => {
   return {

--- a/src/handlers/post-confirm-details-handler/post-confirm-details-handler.ts
+++ b/src/handlers/post-confirm-details-handler/post-confirm-details-handler.ts
@@ -1,23 +1,32 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import logger from "../../commons/logger";
+import { getCookieValues } from "../../commons/cookie-utilities";
+import { redirectToErrorPage } from "../../commons/redirect-utilities";
 
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
   const eventValues = new URLSearchParams(event.body || "");
+  const domainName = process.env.DOMAIN_NAME || "";
 
   const redirectUri = eventValues.get("redirectUri");
   const clientId = eventValues.get("client_id");
   const state = eventValues.get("state");
+  const sessionId = getCookieValues(event)?.get("identity_reuse_service_session");
 
   if (!redirectUri || !state || !clientId) {
     throw new Error("One or more required query string parameters are undefined");
   }
-
-  const url = new URL(`https://${process.env.PUBLIC_API}/oauth2/callback`);
-  url.searchParams.append("redirect_uri", redirectUri);
-  url.searchParams.append("state", state);
-  url.searchParams.append("client_id", clientId);
+  if (!sessionId) {
+    return await redirectToErrorPage(domainName);
+  }
 
   try {
+    await createAuthCode(sessionId);
+
+    const url = new URL(`https://${process.env.PUBLIC_API}/oauth2/callback`);
+    url.searchParams.append("redirect_uri", redirectUri);
+    url.searchParams.append("state", state);
+    url.searchParams.append("client_id", clientId);
+
     return {
       statusCode: 302,
       body: "",
@@ -26,10 +35,21 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
       },
     };
   } catch (error) {
-    logger.error(`Error in lambdaHandler event: ${error}`);
-    return {
-      statusCode: 500,
-      body: "",
-    };
+    logger.error(`Error in lambdaHandler event`, { error });
+    return await redirectToErrorPage(domainName);
   }
+};
+
+const createAuthCode = async (sessionId: string) => {
+  const oauthInternalApiUrl = process.env.OAUTH_INTERNAL_API_URL;
+  const url = new URL(`${oauthInternalApiUrl}/api/create-auth-code`);
+
+  const responseFromCreateAuthCode = await fetch(url, {
+    method: "POST",
+    headers: {
+      "session-id": sessionId,
+    },
+  });
+
+  logger.info("Response from create-auth-code", { sessionId, statusCode: responseFromCreateAuthCode.status });
 };

--- a/src/handlers/post-confirm-details-handler/tests/post-confirm-details-handler.test.ts
+++ b/src/handlers/post-confirm-details-handler/tests/post-confirm-details-handler.test.ts
@@ -1,13 +1,44 @@
 import { APIGatewayEventRequestContextWithAuthorizer, APIGatewayProxyEvent } from "aws-lambda";
-import { expect, it, vi } from "vitest";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { lambdaHandler } from "../post-confirm-details-handler";
+import { randomUUID } from "node:crypto";
 
-it("should return a 302 status code on a successful request", async () => {
+const TEST_SESSION_ID = randomUUID();
+
+beforeEach(() => {
   vi.stubEnv("PUBLIC_API", "api.example.com");
+  vi.stubEnv("DOMAIN_NAME", "api2.example.com");
+});
 
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+it("should redirect to the error page if the session is not provided", async () => {
   const event = createMockAPIGatewayProxyEvent(
     {},
     "redirectUri=https%3A%2F%2Fapi.example.com&state=test-state-id&client_id=client"
+  );
+
+  const response = await lambdaHandler(event);
+  expect(response).toStrictEqual({
+    statusCode: 302,
+    body: "",
+    headers: {
+      Location: "https://api2.example.com/error/unrecoverable",
+    },
+  });
+});
+
+it("should return a 302 status code on a successful request", async () => {
+  vi.stubEnv("OAUTH_INTERNAL_API_URL", "https://internal.example.com");
+
+  const mockFetch = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response("", { status: 201 }));
+
+  const event = createMockAPIGatewayProxyEvent(
+    {},
+    "redirectUri=https%3A%2F%2Fapi.example.com&state=test-state-id&client_id=client",
+    TEST_SESSION_ID
   );
 
   const response = await lambdaHandler(event);
@@ -20,7 +51,14 @@ it("should return a 302 status code on a successful request", async () => {
     },
   });
 
-  vi.unstubAllEnvs();
+  expect(mockFetch).toHaveBeenCalledWith(new URL("https://internal.example.com/api/create-auth-code"), {
+    method: "POST",
+    headers: {
+      "session-id": TEST_SESSION_ID,
+    },
+  });
+
+  mockFetch.mockRestore();
 });
 
 it("should return an error when some query string parameters are missing", async () => {
@@ -35,9 +73,15 @@ it("should return an error when some query string parameters are missing", async
   });
 });
 
-const createMockAPIGatewayProxyEvent = (event: Partial<APIGatewayProxyEvent>, body: string): APIGatewayProxyEvent => ({
+const createMockAPIGatewayProxyEvent = (
+  event: Partial<APIGatewayProxyEvent>,
+  body: string,
+  sessionId?: string
+): APIGatewayProxyEvent => ({
   body: body,
-  headers: {},
+  headers: {
+    ...(sessionId && { cookie: `identity_reuse_service_session=${sessionId}` }),
+  },
   multiValueHeaders: {},
   httpMethod: "POST",
   isBase64Encoded: false,


### PR DESCRIPTION
## What

Updated the PostConfirmDetails Lambda to call the CreateAuthConfFn Lambda in OAuth common. This involved the following changes:
* Added missing `POWERTOOLS_SERVICE_NAME` and `POWERTOOLS_METRICS_NAMESPACE` to some lambdas which was causing CloudWatch to log undefined for the service name.
* Updated OAuth Common SAR version to v0.8.0 as this provides to new `CreateAuthCode` function which is required by `PostConfirmDetailsHandler`
* Added the `/api/create-auth-code` API to the OAuth Common API Gateway and wired this up to the `CreateAuthCodeFn` lambda exported by OAuth Common SAR version v0.8.0.
* Updated the `PostConfirmDetailsHandler` to:
  * Be able to access the OAuth Internal Stack
  * Call the `/api/create-auth-code` API to generate an auth code
  * Redirect to the error page in the event of an error
* Updated the `GetCallbackHandler`:
  * Cleaned up the handler to make it follow the same pattern as other lambdas for the `OAUTH_INTERNAL_API_URL` environment variable.
  * Moved the code to redirect into the `try ... catch`. If the lambdas is incorrectly configured an unhandled exception is thrown if the `OAUTH_INTERNAL_API` is not defined.
* Moved `redirectToErrorPage` and `redirect` functions to common/redirect-utilities.ts so that it can be reused by different lambdas.
* Added various bit of error handling and metrics generation to make debugging easier.

## Why

In order to enable SIS to make use of Common OAuth components, SIS and it’s Orchestration stub will require updates to integrate into the OAuth flow. This ticket ensures that an authentication code is generated and stored in the session table against the session ID after the user clicks “continue” on `/confirm-details`.

## Testing

1. Navigate to https://orch-spt-1968.reuse.dev.stubs.account.gov.uk which is been deployed to test this functionality.
2. At the bottom of the page click Continue
3. The page "Orchestration stub: Response" should appear and the URL will contain the authorization code generated in the Session Table