### PR TITLE
SPT-2019: removes old permissions

### DIFF
--- a/infrastructure/identity-reuse-service/template.yaml
+++ b/infrastructure/identity-reuse-service/template.yaml
@@ -452,22 +452,6 @@ Resources:
         - Key: Source
           Value: !Ref SourceTagValue
 
-  GetAuthorizeHandlerPolicy:
-    Type: AWS::IAM::Policy
-    Condition: IsNotProduction
-    Properties:
-      PolicyName: !Sub "${AWS::StackName}-GetAuthorizeHandlerPolicy"
-      PolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Action:
-              - "secretsmanager:GetSecretValue" #pragma: allowlist secret
-            Resource:
-              - Fn::ImportValue: !Sub "${SharedStackName}-EVCSApiKeySecret"
-      Roles:
-        - !Ref GetAuthorizeHandlerRole
-
   GetAuthorizeHandlerLogGroup:
     Type: AWS::Logs::LogGroup
     Condition: IsNotProduction
@@ -595,22 +579,6 @@ Resources:
           Value: !Ref OwnerTagValue
         - Key: Source
           Value: !Ref SourceTagValue
-
-  GetUserIdentityHandlerPolicy:
-    Type: AWS::IAM::Policy
-    Condition: IsNotProduction
-    Properties:
-      PolicyName: !Sub "${AWS::StackName}-GetUserIdentityHandlerPolicy"
-      PolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Action:
-              - "secretsmanager:GetSecretValue" #pragma: allowlist secret
-            Resource:
-              - Fn::ImportValue: !Sub "${SharedStackName}-EVCSApiKeySecret"
-      Roles:
-        - !Ref GetUserIdentityHandlerRole
 
   GetUserIdentityHandlerLogGroup:
     Type: AWS::Logs::LogGroup
@@ -1590,21 +1558,6 @@ Resources:
         - Key: Source
           Value: !Ref SourceTagValue
 
-  PostPhase2UserIdentityHandlerPolicy:
-    Type: AWS::IAM::Policy
-    Properties:
-      PolicyName: !Sub "${AWS::StackName}-PostPhase2UserIdentityHandlerPolicy"
-      PolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Action:
-              - "secretsmanager:GetSecretValue" #pragma: allowlist secret
-            Resource:
-              - Fn::ImportValue: !Sub "${SharedStackName}-EVCSApiKeySecret"
-      Roles:
-        - !Ref PostPhase2UserIdentityHandlerRole
-
   RegionalGatewayPostPhase2UserIdentityHandlerResourcePolicy:
     Condition: IsDev
     Type: AWS::Lambda::Permission
@@ -1889,15 +1842,6 @@ Resources:
               - IsDevOrBuild
               - !GetAtt StubQueueKey.Arn
               - !FindInMap [EnvironmentMap, !Ref Environment, InboundTxmaQueueKeyArn]
-          - Effect: Allow
-            Action:
-              - "secretsmanager:GetSecretValue" #pragma: allowlist secret
-            Resource:
-              - Fn::ImportValue: !Sub "${SharedStackName}-EVCSApiKeySecret"
-#          - Effect: Allow
-#            Action:
-#              - "kms:*"
-#            Resource: "*"
       Roles:
         - !Ref InboundTxmaQueueMessageHandlerRole
 


### PR DESCRIPTION
## What

<!-- Describe the changes in detail - the "what"-->
<!-- Include all information the reviewer needs for context -->

- Old permissions relevant to `EVCSApiKeySecret` have been deleted
- Any lingering KMS permissions with wildstar (*) access have been deleted

## Why

<!-- Describe the reason these changes were made - the "why" -->
<!-- Include all information the reviewer needs for context -->

- The deleted permissions are now covered by the previously added managed policies

## additional sections as needed

<!-- if you feel the PR description warrants additional detail, add extra sections, for example notes on how to test (if required) -->

## Related PRs

<!-- Include links to any PRs, in this repo or others, related to this change, for example a related configuration change (delete this section if not applicable) -->
https://github.com/govuk-one-login/ipv-identity-reuse-service/pull/415 
https://github.com/govuk-one-login/ipv-identity-reuse-service/pull/414 

https://github.com/govuk-one-login/ipv-identity-reuse-service-config/pull/178
https://github.com/govuk-one-login/ipv-identity-reuse-service-config/pull/186