### PR TITLE
SPT-1994: Do not alert on lambda auth errors in build

### DIFF
--- a/infrastructure/oauth-internal/template.yaml
+++ b/infrastructure/oauth-internal/template.yaml
@@ -174,15 +174,15 @@ Conditions:
       - Fn::Equals: [ !Ref Environment, "local" ]
       - Fn::Equals: [ !Ref Environment, "dev" ]
 
-  IsNotDev:
-    Fn::Not:
-      - !Condition IsDev
-
   IsDevOrBuild:
     Fn::Or:
       - Fn::Equals: [ !Ref Environment, "local" ]
       - Fn::Equals: [ !Ref Environment, "dev" ]
       - Fn::Equals: [ !Ref Environment, "build" ]
+
+  IsNotDevOrBuild:
+    Fn::Not:
+      - !Condition IsDevOrBuild
 
   IsNotProduction:
     Fn::Or:
@@ -679,7 +679,7 @@ Resources:
       TreatMissingData: notBreaching
       ActionsEnabled:
         Fn::If:
-          - IsNotDev
+          - IsNotDevOrBuild
           - TRUE
           - FALSE
       AlarmActions:


### PR DESCRIPTION
## What

Disable the alarm actions for the lambda authoriser to prevent alarms being raised in dev and build.

## Why

The alarms are going off for "Unauthorized" errors, which we don't want. We may need to review how the authoriser works and interacts with the alerting, but for the immediate term, lets disable the alerting.

## Related PRs

#408 