### PR TITLE
SPT-1968: Deploy script deploys orch stub

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,31 @@ To deploy `/infrastructure/oauth-internal/template.yaml` you need additional opt
 ./deploy-to-dev.sh -s $STACK_NAME -o -n -m $ANOTHER_SIS_STACK
 ```
 
+### Deploying orchestration-stub
+
+You will need to check out `ipv-reuse-service-stubs` in the same folder as the `ipv-identity-reuse-service` repository,
+which contains the orchestration-stub. You will then have the following options which will enable you to deploy the
+stub:
+
+```
+-c, --orch-deploy       Deploy the orchestration-stub stack (optional)
+-p, --stubs-profile     The AWS profile for the stubs environment. (default = 'stubs-dev')
+```
+
+You can deploy Orchestration stub, SIS and OAuth common using the following command:
+
+```sh
+./deploy-to-dev.sh -a sis-dev -p stubs-dev -s dev-test -o -c -y
+```
+
+Where:
+* `-a` the account profile that SIS and OAuth common will be deployed to
+* `-p` the account profile that Orchestration Stub will be deployed to
+* `-s` the name of the stacks, where in this example SIS and Orchestration Stub will be deployed as dev-test and OAuth common will be deployed as `dev-test-oauth`.
+* `-o` deploy OAuth common
+* `-c` deploy Orchestration Stub
+* `-y` disable confirmations
+
 ### Delete your stack deployment
 
 When you have finished testing, you'll need to manually delete the stack(s) you created by adding `-d` to any of the commands:

--- a/deploy-to-dev.sh
+++ b/deploy-to-dev.sh
@@ -13,6 +13,8 @@ Usage:
     -s      --stack-name        The name of the stack to deploy.
     -e      --environment       Environment that the stack is being deployed to. (default = 'local')
     -o      --oauth-deploy      Deploy the oauth-internal stack (optional)
+    -c      --orch-deploy       Deploy the orchestration-stub stack (optional)
+    -p      --stubs-profile     The AWS profile for the stubs environment. (default = 'stubs-dev')
     -n      --no-sis-deploy     Do not deploy the identity-reuse-service stack (optional)
     -m      --shared-stack-name The name of an existing identity-reuse-shared stack that the oauth-internal can point
                                 at for audit infrastructure. (optional)
@@ -27,170 +29,296 @@ EOF
   return 0
 }
 
-deploy_or_destroy() {
-  pushd "${BASE_DIR}"
+parse_args() {
+  DEPLOY_SIS=true
+  DEPLOY_OAUTH=false
+  DEPLOY_ORCH=false
+  STUBS_PROFILE="stubs-dev"
+  SHARED_STACK_NAME="reuse-identity-shared"
+  RESOLVE_S3=false
+  CONFIRM_CHANGES=true
+  BUILD_CACHE="--cached"
+  OPERATION="deploy"
+  ENVIRONMENT="dev"
+  AWS_PROFILE="sis-dev"
+  AWS_DEFAULT_REGION=eu-west-2
+  SAM_CMD=sam
 
-  TEMPLATE_FILE="infrastructure/${1}/template.yaml"
-  BUILD_DIR=".aws-sam/build/${1}"
-  shift
-  STACK_NAME=${1}
-  shift
-
-  SAM_CONFIG="infrastructure/${1}/samconfig.toml"
-  [[ -e "${SAM_CONFIG}" ]] || RESOLVE_S3=true
-  if "${RESOLVE_S3}"; then
-    BUCKET_PARAM=("--resolve-s3")
-  else
-    BUCKET_PARAM=("--config-file" "../../../$SAM_CONFIG")
+  if [[ "${OSTYPE}" =~ ^msys ]]; then
+    SAM_CMD=sam.cmd
   fi
 
-  case $OPERATION in
-    deploy)
-      echo "Validating ${TEMPLATE_FILE}..."
-      $SAM_CMD validate \
-        --template-file "${TEMPLATE_FILE}" \
-        --profile "${AWS_PROFILE}"
-      echo
+  while [[ -n "${1}" ]]; do
+    case "${1}" in
+      -a | --aws-profile)
+        shift
+        export AWS_PROFILE="${1}"
+        ;;
+      -s | --stack-name)
+        shift
+        STACK_NAME="${1}"
+        ;;
+      -e | --environment)
+        shift
+        ENVIRONMENT="${1}"
+        ;;
+      -o | --oauth-deploy)
+        DEPLOY_OAUTH=true
+        ;;
+      -c | --orch-deploy)
+        DEPLOY_ORCH=true
+        ;;
+      -p | --stubs-profile)
+        shift
+        STUBS_PROFILE="${1}"
+        ;;
+      -n | --no-sis-deploy)
+        DEPLOY_SIS=false
+        ;;
+      -m | --shared-stack-name)
+        shift
+        SHARED_STACK_NAME="${1}"
+        ;;
+      -r | --resolve-s3)
+        RESOLVE_S3=true
+        ;;
+      -f | --force-build)
+        BUILD_CACHE=""
+        ;;
+      -y | --no-confirm)
+        CONFIRM_CHANGES=false
+        ;;
+      -d | --destroy)
+        OPERATION="destroy"
+        ;;
+      -h | --help)
+        usage
+        exit 0
+        ;;
+      *)
+        echo -e "Unknown option ${1}...\n"
+        usage
+        exit 1
+        ;;
+    esac
+    shift
+  done
 
-      echo "Building ${TEMPLATE_FILE}..."
-      $SAM_CMD build --parallel --beta-features "${BUILD_CACHE}" \
-        --template-file "${TEMPLATE_FILE}" \
-        --build-dir "${BUILD_DIR}"
-      echo
+  if "${CONFIRM_CHANGES}"; then
+    CONFIRM_CHANGES_PARAM="--confirm-changeset"
+  else
+    CONFIRM_CHANGES_PARAM="--no-confirm-changeset"
+  fi
 
-      echo "Deploying ${TEMPLATE_FILE} to stack ${STACK_NAME}..."
-      $SAM_CMD deploy \
-        --template-file "${BUILD_DIR}/template.yaml" \
-        --stack-name "${STACK_NAME}" \
-        --s3-prefix "${STACK_NAME}" \
-        "${BUCKET_PARAM[@]}" \
-        "${CONFIRM_CHANGES_PARAM}" \
-        --capabilities CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND \
-        --no-fail-on-empty-changeset \
-        --profile "${AWS_PROFILE}" \
-        --tags DeploymentSource=Manual StackType=Dev Project="ipv-identity-reuse-service" \
-        --parameter-overrides Environment="${ENVIRONMENT}" "$@"
-      echo
-      ;;
-    destroy)
-      echo "Destroying stack ${STACK_NAME}..."
-      $SAM_CMD delete \
-        --stack-name "${STACK_NAME}" \
-        --profile "${AWS_PROFILE}"
-      echo
-      ;;
-    *)
-      popd
-      echo -e "Unknown operation ${OPERATION}...\n"
-      usage
-      exit 1
-      ;;
-  esac
+  if [[ -z "${STACK_NAME}" ]]; then
+    echo "Please specify a stack name."
+    usage
+    exit 1
+  fi
+
+  if "${DEPLOY_SIS}"; then
+    SIS_STACK_NAME="${STACK_NAME}"
+    if "${DEPLOY_OAUTH}"; then
+      OAUTH_STACK_NAME="${STACK_NAME}-oauth"
+    else
+      OAUTH_STACK_NAME="preview-main-oauth"
+    fi
+  elif "${DEPLOY_OAUTH}" || "${DEPLOY_ORCH}"; then
+    SIS_STACK_NAME="${STACK_NAME}"
+    OAUTH_STACK_NAME="${STACK_NAME}"
+  else
+    echo "Nothing to deploy. Using --no-sis-deploy without --oauth-deploy or --orch-deploy means I don't do anything."
+    usage
+    exit 1
+  fi
+
+  if "${DEPLOY_ORCH}"; then
+    ORCH_STACK_NAME="${STACK_NAME}"
+  fi
+}
+
+get_sis_outputs() {
+  local sis_stack_name="${1}"
+
+  echo "Fetching SIS stack outputs from stack '${sis_stack_name}' (profile: ${AWS_PROFILE})..."
+
+  SIS_PUBLIC_API_OUTPUT=$(aws cloudformation describe-stacks \
+    --stack-name "${sis_stack_name}" \
+    --profile "${AWS_PROFILE}" \
+    --region eu-west-2 \
+    --query "Stacks[0].Outputs[?OutputKey=='SisPublicApi'].OutputValue" \
+    --output text)
+
+  if [[ -z "${SIS_PUBLIC_API_OUTPUT}" || "${SIS_PUBLIC_API_OUTPUT}" == "None" ]]; then
+    echo "Error: Could not retrieve SisPublicApi output from stack '${sis_stack_name}'."
+    exit 1
+  fi
+
+  SIS_PRIVATE_API_OUTPUT=$(aws cloudformation describe-stacks \
+    --stack-name "${sis_stack_name}" \
+    --profile "${AWS_PROFILE}" \
+    --region eu-west-2 \
+    --query "Stacks[0].Outputs[?OutputKey=='SisPrivateApi'].OutputValue" \
+    --output text)
+
+  if [[ -z "${SIS_PRIVATE_API_OUTPUT}" || "${SIS_PRIVATE_API_OUTPUT}" == "None" ]]; then
+    echo "Error: Could not retrieve SisPrivateApi output from stack '${sis_stack_name}'."
+    exit 1
+  fi
+
+  echo "SisPublicApi:  ${SIS_PUBLIC_API_OUTPUT}"
+  echo "SisPrivateApi: ${SIS_PRIVATE_API_OUTPUT}"
+}
+
+resolve_bucket_param() {
+  local component="${1}"
+  local sam_config="infrastructure/${component}/samconfig.toml"
+
+  if [[ -e "${sam_config}" ]] && ! "${RESOLVE_S3}"; then
+    BUCKET_PARAM=("--config-file" "../../../${sam_config}")
+  else
+    BUCKET_PARAM=("--resolve-s3")
+  fi
+}
+
+deploy() {
+  local component="${1}"
+  local stack_name="${2}"
+  shift 2
+
+  local template_file="infrastructure/${component}/template.yaml"
+  local build_dir=".aws-sam/build/${component}"
+
+  pushd "${BASE_DIR}"
+  resolve_bucket_param "${component}"
+
+  echo -e "\n\033[1;34m==> Deploying component '${component}' to stack '${stack_name}'\033[0m\n"
+
+  echo "Validating ${template_file}..."
+  $SAM_CMD validate \
+    --template-file "${template_file}" \
+    --profile "${AWS_PROFILE}"
+  echo
+
+  echo "Building ${template_file}..."
+  $SAM_CMD build --parallel --beta-features "${BUILD_CACHE}" \
+    --template-file "${template_file}" \
+    --build-dir "${build_dir}"
+  echo
+
+  echo "Deploying ${template_file} to stack ${stack_name}..."
+  $SAM_CMD deploy \
+    --template-file "${build_dir}/template.yaml" \
+    --stack-name "${stack_name}" \
+    --s3-prefix "${stack_name}" \
+    "${BUCKET_PARAM[@]}" \
+    "${CONFIRM_CHANGES_PARAM}" \
+    --capabilities CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND \
+    --no-fail-on-empty-changeset \
+    --profile "${AWS_PROFILE}" \
+    --tags DeploymentSource=Manual StackType=Dev Project="ipv-identity-reuse-service" \
+    --parameter-overrides Environment="${ENVIRONMENT}" "$@"
+  echo
+
   popd
 }
 
-DEPLOY_SIS=true
-DEPLOY_OAUTH=false
-SHARED_STACK_NAME="reuse-identity-shared"
-RESOLVE_S3=false
-CONFIRM_CHANGES=true
-BUILD_CACHE="--cached"
-OPERATION="deploy"
-ENVIRONMENT="local"
-AWS_PROFILE="sis-dev"
+destroy() {
+  local component="${1}"
+  local stack_name="${2}"
 
-while [[ -n "${1}" ]]; do
-  case "${1}" in
-    -a | --aws-profile)
-      shift
-      export AWS_PROFILE="${1}"
-      ;;
-    -s | --stack-name)
-      shift
-      STACK_NAME="${1}"
-      ;;
-    -e | --environment)
-      shift
-      ENVIRONMENT="${1}"
-      ;;
-    -o | --oauth-deploy)
-      DEPLOY_OAUTH=true
-      ;;
-    -n | --no-sis-deploy)
-      DEPLOY_SIS=false
-      ;;
-    -m | --shared-stack-name)
-      shift
-      SHARED_STACK_NAME="${1}"
-      ;;
-    -r | --resolve-s3)
-      RESOLVE_S3=true
-      ;;
-    -f | --force-build)
-      BUILD_CACHE=""
-      ;;
-    -y | --no-confirm)
-      CONFIRM_CHANGES=false
-      ;;
-    -d | --destroy)
-      OPERATION="destroy"
-      ;;
-    -h | --help)
-      usage
-      exit 0
-      ;;
-    *)
-      echo -e "Unknown option ${1}...\n"
-      usage
-      exit 1
-      ;;
-  esac
-  shift
-done
+  pushd "${BASE_DIR}"
 
-if "${CONFIRM_CHANGES}"; then
-  CONFIRM_CHANGES_PARAM="--confirm-changeset"
-else
-  CONFIRM_CHANGES_PARAM="--no-confirm-changeset"
-fi
+  echo -e "\n\033[1;31m==> Destroying component '${component}' from stack '${stack_name}'\033[0m\n"
 
-if [[ -z "${STACK_NAME}" ]]; then
-  echo "Please specify a stack name."
-  usage
-  exit 1
-fi
+  $SAM_CMD delete \
+    --stack-name "${stack_name}" \
+    --profile "${AWS_PROFILE}"
+  echo
 
-if "${DEPLOY_SIS}"; then
-    SIS_STACK_NAME="${STACK_NAME}"
-    if "${DEPLOY_OAUTH}"; then
-        OAUTH_STACK_NAME="${STACK_NAME}-oauth"
-    else
-        OAUTH_STACK_NAME="preview-main-oauth"
-    fi
-elif "${DEPLOY_OAUTH}"; then
-  OAUTH_STACK_NAME="${STACK_NAME}"
-else
-  echo "Nothing to deploy. Using --no-sis-deploy without --oauth-deploy means I don't do anything."
-  usage
-  exit 1
-fi
+  popd
+}
 
-SAM_CMD=sam
-if [[ "${OSTYPE}" =~ ^msys ]]; then
-  SAM_CMD=sam.cmd
-fi
+deploy_orch() {
+  local stack_name="${1}"
+  local orch_dir="${BASE_DIR}/../ipv-reuse-service-stubs/orchestration-stub"
 
-export AWS_DEFAULT_REGION=eu-west-2
-echo "Environment: ${ENVIRONMENT}"
-echo "Profile:     ${AWS_PROFILE}"
-$DEPLOY_SIS && echo "Deploy identity-reuse-service to stack ${SIS_STACK_NAME}, pointing at shared stack ${SHARED_STACK_NAME}"
-$DEPLOY_OAUTH && echo "Deploy oauth-internal to stack ${OAUTH_STACK_NAME}, pointing at shared stack ${SHARED_STACK_NAME}"
+  echo -e "\n\033[1;34m==> Deploying orchestration-stub to stack '${stack_name}' (profile: ${STUBS_PROFILE})\033[0m\n"
+
+  pushd "${orch_dir}"
+
+  echo "Building orchestration-stub..."
+  $SAM_CMD build --parallel --beta-features ${BUILD_CACHE}
+  echo
+
+  echo "Deploying orchestration-stub to stack ${stack_name}..."
+  $SAM_CMD deploy \
+    --stack-name "${stack_name}" \
+    --resolve-s3 \
+    --s3-prefix "${stack_name}" \
+    "${CONFIRM_CHANGES_PARAM}" \
+    --capabilities CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND \
+    --no-fail-on-empty-changeset \
+    --profile "${STUBS_PROFILE}" \
+    --tags DeploymentSource=Manual StackType=Dev Project="ipv-reuse-service-stubs" \
+    --parameter-overrides \
+      Environment="${ENVIRONMENT}" \
+      PublicAuthApiOverride="${SIS_PUBLIC_API_OUTPUT}" \
+      PrivateAuthApiOverride="${SIS_PRIVATE_API_OUTPUT}"
+  echo
+
+  popd
+}
+
+destroy_orch() {
+  local stack_name="${1}"
+
+  echo -e "\n\033[1;31m==> Destroying orchestration-stub from stack '${stack_name}' (profile: ${STUBS_PROFILE})\033[0m\n"
+
+  $SAM_CMD delete \
+    --stack-name "${stack_name}" \
+    --profile "${STUBS_PROFILE}"
+  echo
+}
+
+parse_args "$@"
+
+echo -e "\033[32mEnvironment:\033[0m ${ENVIRONMENT}"
+echo -e "\033[32mProfile:\033[0m     ${AWS_PROFILE}"
+$DEPLOY_SIS && echo -e "\033[32mDeploy identity-reuse-service to stack ${SIS_STACK_NAME}, pointing at shared stack ${SHARED_STACK_NAME}\033[0m"
+$DEPLOY_OAUTH && echo -e "\033[32mDeploy oauth-internal to stack ${OAUTH_STACK_NAME}, pointing at shared stack ${SHARED_STACK_NAME}\033[0m"
+$DEPLOY_ORCH && echo -e "\033[32mDeploy orchestration-stub to stack ${ORCH_STACK_NAME} (profile: ${STUBS_PROFILE})\033[0m"
 echo
 
-if "${DEPLOY_OAUTH}"; then
-  deploy_or_destroy "oauth-internal" "${OAUTH_STACK_NAME}" "SharedStackName=${SHARED_STACK_NAME}"
-fi
+if [[ "${OPERATION}" == "destroy" ]]; then
+  if "${DEPLOY_ORCH}"; then
+    destroy_orch "${ORCH_STACK_NAME}"
+  fi
 
-if "${DEPLOY_SIS}"; then
-  deploy_or_destroy "identity-reuse-service" "${SIS_STACK_NAME}" "OauthInternalStackName=${OAUTH_STACK_NAME}" "SharedStackName=${SHARED_STACK_NAME}"
+  if "${DEPLOY_SIS}"; then
+    destroy "identity-reuse-service" "${SIS_STACK_NAME}"
+  fi
+
+  if "${DEPLOY_OAUTH}"; then
+    destroy "oauth-internal" "${OAUTH_STACK_NAME}"
+  fi
+else
+  if "${DEPLOY_OAUTH}"; then
+    OAUTH_PARAMS=("SharedStackName=${SHARED_STACK_NAME}")
+    if "${DEPLOY_ORCH}"; then
+      ORCH_BASE_URL="https://orch-${ORCH_STACK_NAME}.reuse.dev.stubs.account.gov.uk"
+      OAUTH_PARAMS+=("OrchestrationJwksEndpointOverride=${ORCH_BASE_URL}/.well-known/jwks.json")
+      OAUTH_PARAMS+=("OrchestrationRedirectURIOverride=${ORCH_BASE_URL}")
+    fi
+    deploy "oauth-internal" "${OAUTH_STACK_NAME}" "${OAUTH_PARAMS[@]}"
+  fi
+
+  if "${DEPLOY_SIS}"; then
+    deploy "identity-reuse-service" "${SIS_STACK_NAME}" "OauthInternalStackName=${OAUTH_STACK_NAME}" "SharedStackName=${SHARED_STACK_NAME}"
+  fi
+
+  if "${DEPLOY_ORCH}"; then
+    get_sis_outputs "${SIS_STACK_NAME}"
+    deploy_orch "${ORCH_STACK_NAME}"
+  fi
 fi


### PR DESCRIPTION
## What

Added the ability for the deploy script to also deploy the orchestration stub.

## Why

There is a cyclic dependency between Orchestration, SIS and OAuth common so we need to be able to deploy all three of these and feed in our outputs from each stack into the other.
