### PR TITLE
BAU: Added the ability to delete OAuth stacks

### DIFF
--- a/.github/workflows/delete-deployment.yaml
+++ b/.github/workflows/delete-deployment.yaml
@@ -45,22 +45,21 @@ jobs:
           branch-name: preview-pr-${{ github.event.pull_request.number }}
           length-limit: ${{ env.STACK_NAME_LENGTH }}
 
-#       N.B Uncomment this once the OAuth stack can be deployed
-#      - name: Get OAuth stack name
-#        id: get-oauth-stack-name
-#        if: ${{ github.event_name != 'schedule' }}
-#        uses: govuk-one-login/github-actions/beautify-branch-name@f5362528578198e7851e96e0594f593beff0162e
-#        with:
-#          usage: Stack name
-#          branch-name: preview-pr-${{ github.event.pull_request.number }}-oauth
-#          length-limit: ${{ env.STACK_NAME_LENGTH }}
+      - name: Get OAuth stack name
+        id: get-oauth-stack-name
+        if: ${{ github.event_name != 'schedule' }}
+        uses: govuk-one-login/github-actions/beautify-branch-name@f5362528578198e7851e96e0594f593beff0162e
+        with:
+          usage: Stack name
+          branch-name: preview-oauth-pr-${{ github.event.pull_request.number }}
+          length-limit: ${{ env.STACK_NAME_LENGTH }}
 
-      - name: Check stack exists
+      - name: Check stacks exist
         if: ${{ github.event_name != 'schedule' }}
         id: check-stack-exists
         uses: govuk-one-login/github-actions/sam/check-stacks-exist@f5362528578198e7851e96e0594f593beff0162e
         with:
-          stack-names: ${{ steps.get-stack-name.outputs.pretty-branch-name }}
+          stack-names: ${{ steps.get-stack-name.outputs.pretty-branch-name }} ${{ steps.get-oauth-stack-name.outputs.pretty-branch-name }}
           set-env-var: STACKS_TO_DELETE
           verbose: true
 


### PR DESCRIPTION
## What

Uncommented and updated code to allow OAuth stacks to be deleted.

## Why

We have been getting a build up of deployed stale stacks which are not being deleted.

## Manual testing

There is a test run here https://github.com/govuk-one-login/ipv-identity-reuse-service/actions/runs/31010501942/job/92321140176