### PR TITLE
SPT-2042: Published key bucket and API Gateway lambda authoriser fixes

### DIFF
--- a/infrastructure/identity-reuse-service/template.yaml
+++ b/infrastructure/identity-reuse-service/template.yaml
@@ -2481,8 +2481,11 @@ Resources:
                   - "s3:GetObject"
                   - "s3:ListBucket"
                 Resource:
-                  - !Sub "arn:aws:s3:::govuk-one-login-${ServiceName}-published-keys-${Environment}"
-                  - !Sub "arn:aws:s3:::govuk-one-login-${ServiceName}-published-keys-${Environment}/jwks.json"
+                  - Fn::ImportValue: !Sub "${SharedStackName}-PublishedKeysS3BucketArn"
+                  - !Sub
+                    - "${BucketArn}/jwks.json"
+                    - BucketArn:
+                        Fn::ImportValue: !Sub "${SharedStackName}-PublishedKeysS3BucketArn"
       Tags:
         - Key: "key_consumer_type"
           Value: "use"

--- a/openAPI/public-api.yaml
+++ b/openAPI/public-api.yaml
@@ -23,7 +23,11 @@ paths:
         credentials:
           Fn::GetAtt: RestOAuthDocumentResourceS3Role.Arn
         uri:
-          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:s3:path/govuk-one-login-${ServiceName}-published-keys-${Environment}/jwks.json"
+          Fn::Sub:
+            - "arn:aws:apigateway:${AWS::Region}:s3:path/${BucketName}/jwks.json"
+            - BucketName:
+                Fn::ImportValue:
+                  Fn::Sub: "${SharedStackName}-PublishedKeysS3Bucket"
         passthroughBehavior: WHEN_NO_MATCH
         httpMethod: GET
         type: aws

--- a/src/handlers/api-gateway-protected-resource-authorizer-handler/api-gateway-protected-resource-authorizer-handler.ts
+++ b/src/handlers/api-gateway-protected-resource-authorizer-handler/api-gateway-protected-resource-authorizer-handler.ts
@@ -53,7 +53,7 @@ export const handler = async (
       KeyConditionExpression: "accessToken = :tokenValue",
       ExpressionAttributeValues: {
         ":tokenValue": {
-          S: authorizationHeader?.slice(7),
+          S: authorizationHeader,
         },
       },
     });

--- a/src/handlers/api-gateway-protected-resource-authorizer-handler/tests/api-gateway-bearer-protected-resource-handler.test.ts
+++ b/src/handlers/api-gateway-protected-resource-authorizer-handler/tests/api-gateway-bearer-protected-resource-handler.test.ts
@@ -16,7 +16,7 @@ describe("api-gateway-bearer-token-authorizer-handler", () => {
 
   describe("return a allow policy", () => {
     it("should return an allow policy and subject and storageToken when bearer token is present and valid", async () => {
-      const accessToken = "abcd1234";
+      const accessToken = "Bearer abcd1234";
       const subjectId = "urn:uuid:569faa50-71fe-4d12-b54f-9809483fec0c";
       const storageToken = "abcd.1234.xyz";
       const dynamodbDocumentMock = mockClient(DynamoDBDocumentClient);


### PR DESCRIPTION
## What

- Import published keys bucket name/ARN from `shared` stack to allow reuse of `dev` bucket in `local` environments.
- Fix the authoriser by including the `Bearer ` prefix in the database lookup as, it turns out, this is how the OAuth common persists the token to the database.

## Why

The correct use of the bucket ensures the `/.well-known/jwks.json` endpoint is pointing at a valid bucket and allows the orchestration stub to pick up the valid encryption keys to form the JAR.

The authoriser function fix allows the full end-to-end to work and fixes issues currently being seen while testing.

## Related PRs


